### PR TITLE
chore: update documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ results = reviews.assign(
 
 **Result**: Thousands of reviews classified and analyzed in minutes, not days.
 
-📓 **[Try it yourself →](https://openaivec.anareg.design/examples/pandas/)**
+📓 **[Try it yourself →](https://microsoft.github.io/openaivec/examples/pandas/)**
 
 ## 💡 Real-World Impact
 
@@ -69,7 +69,7 @@ survey_responses.assign(
 ).ai.extract("structured")  # Auto-expands to columns
 ```
 
-📓 **[See more examples →](https://openaivec.anareg.design/examples/)**
+📓 **[See more examples →](https://microsoft.github.io/openaivec/examples/)**
 
 # Overview
 
@@ -135,7 +135,7 @@ result = client.parse(["panda", "rabbit", "koala"], batch_size=32)
 print(result)  # Expected output: ['bear family', 'rabbit family', 'koala family']
 ```
 
-📓 **[Complete tutorial →](https://openaivec.anareg.design/examples/pandas/)**
+📓 **[Complete tutorial →](https://microsoft.github.io/openaivec/examples/pandas/)**
 
 ### Pandas Integration (Recommended)
 
@@ -165,13 +165,13 @@ result = df.assign(
 | rabbit | rabbit family | meadow  | Can see nearly 360 degrees  |
 | koala  | marsupial family | tree   | Sleeps 22 hours per day    |
 
-📓 **[Interactive pandas examples →](https://openaivec.anareg.design/examples/pandas/)**
+📓 **[Interactive pandas examples →](https://microsoft.github.io/openaivec/examples/pandas/)**
 
 ## Using with Apache Spark UDFs
 
 Scale to enterprise datasets with distributed processing:
 
-📓 **[Complete Spark tutorial →](https://openaivec.anareg.design/examples/spark/)**
+📓 **[Complete Spark tutorial →](https://microsoft.github.io/openaivec/examples/spark/)**
 
 First, obtain a Spark session:
 
@@ -283,7 +283,7 @@ In particular, providing a few examples in a prompt can significantly improve an
 a technique known as "few-shot learning." Typically, a few-shot prompt consists of a purpose, cautions,
 and examples.
 
-📓 **[Advanced prompting techniques →](https://openaivec.anareg.design/examples/prompt/)**
+📓 **[Advanced prompting techniques →](https://microsoft.github.io/openaivec/examples/prompt/)**
 
 The `FewShotPromptBuilder` helps you create structured, high-quality prompts with examples, cautions, and automatic improvement.
 
@@ -511,11 +511,11 @@ uv run ruff check . --fix
 
 ## Additional Resources
 
-📓 **[Customer feedback analysis →](https://openaivec.anareg.design/examples/customer_analysis/)** - Sentiment analysis & prioritization  
-📓 **[Survey data transformation →](https://openaivec.anareg.design/examples/survey_transformation/)** - Unstructured to structured data  
-📓 **[Asynchronous processing examples →](https://openaivec.anareg.design/examples/aio/)** - High-performance async workflows  
-📓 **[Auto-generate FAQs from documents →](https://openaivec.anareg.design/examples/generate_faq/)** - Create FAQs using AI  
-📓 **[All examples →](https://openaivec.anareg.design/examples/)** - Complete collection of tutorials and use cases
+📓 **[Customer feedback analysis →](https://microsoft.github.io/openaivec/examples/customer_analysis/)** - Sentiment analysis & prioritization  
+📓 **[Survey data transformation →](https://microsoft.github.io/openaivec/examples/survey_transformation/)** - Unstructured to structured data  
+📓 **[Asynchronous processing examples →](https://microsoft.github.io/openaivec/examples/aio/)** - High-performance async workflows  
+📓 **[Auto-generate FAQs from documents →](https://microsoft.github.io/openaivec/examples/generate_faq/)** - Create FAQs using AI  
+📓 **[All examples →](https://microsoft.github.io/openaivec/examples/)** - Complete collection of tutorials and use cases
 
 ## Community
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,13 +1,3 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/onboardsupport](https://aka.ms/onboardsupport). CSS will work with/help you to determine next steps.
-- **Not sure?** Fill out an intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
 # Support
 
 ## How to file issues and get help  
@@ -16,10 +6,8 @@ This project uses GitHub Issues to track bugs and feature requests. Please searc
 issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
 feature request as a new Issue.
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
+For help and questions about using this project, please check the existing GitHub Issues or create a new issue. You can also refer to the project documentation for usage examples and API reference.
 
 ## Microsoft Support Policy  
 
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+Support for this **openaivec** is limited to the resources listed above.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Perfect for **data scientists**, **analysts**, and **ML engineers** who want to 
 ## Links
 - [GitHub Repository](https://github.com/microsoft/openaivec/)
 - [PyPI Package](https://pypi.org/project/openaivec/)
-- [Complete Documentation](https://openaivec.anareg.design/)
+- [Complete Documentation](https://microsoft.github.io/openaivec/)
 
 ## 📚 Examples & Tutorials
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://openaivec.anareg.design/sitemap.xml
+Sitemap: https://microsoft.github.io/openaivec/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: openaivec - AI-Powered Data Processing for Pandas & Spark
-site_url: https://openaivec.anareg.design
+site_url: https://microsoft.github.io/openaivec/
 site_description: Transform your data analysis with OpenAI's language models. Comprehensive task domains including NLP, customer support, and future business domains. Seamlessly integrate structured AI processing, multilingual analysis, and automated workflows into pandas DataFrames and Apache Spark for scalable enterprise insights.
 site_author: Hiroki Mizukami
 repo_url: https://github.com/microsoft/openaivec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ line-length = 120
 target-version = "py310"
 
 [project.urls]
-Homepage = "https://openaivec.anareg.design/"
+Homepage = "https://microsoft.github.io/openaivec/"
 Repository = "https://github.com/microsoft/openaivec"
 
 [build-system]


### PR DESCRIPTION
This pull request updates all references to the old documentation and example URLs (`openaivec.anareg.design`) to the new URL (`microsoft.github.io/openaivec`) across the project. Additionally, it improves the `SUPPORT.md` file by removing placeholders and providing clear instructions for users seeking help.

### Documentation and URL Updates:
* Updated example and tutorial links in `README.md` to point to `microsoft.github.io/openaivec`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R72) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L138-R138) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L168-R174) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L286-R286) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L514-R518)
* Updated the "Complete Documentation" link in `docs/index.md` to the new URL.
* Updated the sitemap URL in `docs/robots.txt` to reflect the new domain.
* Changed the `site_url` in `mkdocs.yml` to `microsoft.github.io/openaivec`.
* Updated the homepage URL in `pyproject.toml` to the new domain.

### Support Documentation Improvements:
* Removed placeholder text from `SUPPORT.md` and added clear instructions for filing issues and seeking help. [[1]](diffhunk://#diff-c5fe610b0215b144474106251cab954f8af55fe26cbd5d2265fd6ca19109c97bL1-L10) [[2]](diffhunk://#diff-c5fe610b0215b144474106251cab954f8af55fe26cbd5d2265fd6ca19109c97bL19-R13)