### PR TITLE
Refactor/spark

### DIFF
--- a/src/openaivec/model.py
+++ b/src/openaivec/model.py
@@ -4,6 +4,7 @@ from typing import Type, TypeVar
 from pydantic import BaseModel
 
 T = TypeVar("T", bound=BaseModel)
+ResponseFormat = Type[BaseModel] | Type[str]
 
 
 @dataclass(frozen=True)

--- a/src/openaivec/model.py
+++ b/src/openaivec/model.py
@@ -4,7 +4,6 @@ from typing import Type, TypeVar
 from pydantic import BaseModel
 
 T = TypeVar("T", bound=BaseModel)
-ResponseFormat = Type[BaseModel] | Type[str]
 
 
 @dataclass(frozen=True)

--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -142,7 +142,6 @@ __all__ = [
     "similarity_udf",
 ]
 
-ResponseFormat = BaseModel | Type[str]
 T = TypeVar("T", bound=BaseModel)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)

--- a/src/openaivec/task/table/fillna.py
+++ b/src/openaivec/task/table/fillna.py
@@ -65,7 +65,7 @@ Example:
 """
 
 import json
-from typing import Dict, List, Union
+from typing import Dict, List
 
 import pandas as pd
 from pydantic import BaseModel, Field
@@ -120,7 +120,7 @@ class FillNaResponse(BaseModel):
     """
 
     index: int = Field(description="Index of the row in the original DataFrame")
-    output: Union[int, float, str, bool, None] = Field(
+    output: int | float | str | bool | None = Field(
         description="Filled value for the target column. This value should be JSON-compatible and match the target column type in the original DataFrame."
     )
 


### PR DESCRIPTION
This pull request refactors the OpenAI client initialization process in `src/openaivec/spark.py` and updates type hints in `src/openaivec/task/table/fillna.py` to align with modern Python syntax. The changes improve code maintainability and readability by removing unnecessary dependencies and adopting environment variable-based configuration.

### Refactoring OpenAI client initialization:

* [`src/openaivec/spark.py`](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL145-R169): Replaced the use of `AsyncOpenAI` and `AsyncAzureOpenAI` clients with environment variable-based configuration for OpenAI and Azure OpenAI client setup. This simplifies the initialization process and removes the dependency on `pandas_ext.use_async`.

### Modernizing type hints:

* [`src/openaivec/spark.py`](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL145-R169): Removed the unused `ResponseFormat` type alias.
* [`src/openaivec/task/table/fillna.py`](diffhunk://#diff-627765db4841b12eb025bc6998f17a7b1fd7ec54645316b7df9f828408033896L123-R123): Updated type hints for the `output` field in the `FillNaResponse` class to use the modern union syntax (`int | float | str | bool | None`).

### Code cleanup:

* [`src/openaivec/spark.py`](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL145-R169): Removed the `_INITIALIZED` global variable, as it is no longer needed with the new initialization approach.
* [`src/openaivec/task/table/fillna.py`](diffhunk://#diff-627765db4841b12eb025bc6998f17a7b1fd7ec54645316b7df9f828408033896L68-R68): Removed an unused `Union` import to clean up the code.