### PR TITLE
Hotfix/spark

### DIFF
--- a/docs/examples/spark.ipynb
+++ b/docs/examples/spark.ipynb
@@ -18,19 +18,22 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "25/05/05 23:13:06 WARN Utils: Your hostname, Hirokis-MacBook-Pro.local resolves to a loopback address: 127.0.0.1; using 192.168.1.12 instead (on interface en0)\n",
-      "25/05/05 23:13:06 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
+      "WARNING: Using incubator modules: jdk.incubator.vector\n",
+      "Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties\n",
       "Setting default log level to \"WARN\".\n",
       "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
-      "25/05/05 23:13:06 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "25/08/05 06:45:58 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
      ]
     }
    ],
    "source": [
     "# Initialize Spark session\n",
+    "import os\n",
     "from pyspark.sql import SparkSession\n",
     "\n",
-    "spark = SparkSession.builder.getOrCreate()"
+    "spark = SparkSession.builder.getOrCreate()\n",
+    "sc = spark.sparkContext\n",
+    "sc.environment[\"OPENAI_API_KEY\"] = os.environ.get(\"OPENAI_API_KEY\")"
    ]
   },
   {
@@ -63,7 +66,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "                                                                                \r"
+      "[Stage 0:>                                                          (0 + 1) / 1]\r"
      ]
     },
     {
@@ -85,6 +88,13 @@
       "|strawberry|\n",
       "+----------+\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
      ]
     }
    ],
@@ -110,7 +120,7 @@
     {
      "data": {
       "text/plain": [
-       "<pyspark.sql.udf.UserDefinedFunction at 0x10b1e1b40>"
+       "<pyspark.sql.udf.UserDefinedFunction at 0x1264d20d0>"
       ]
      },
      "execution_count": 4,
@@ -157,13 +167,6 @@
       "+----------+-----------+\n",
       "\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
     }
    ],
    "source": [
@@ -187,16 +190,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<pyspark.sql.udf.UserDefinedFunction at 0x10e2cc4c0>"
+       "<pyspark.sql.udf.UserDefinedFunction at 0x126701e00>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -207,24 +210,21 @@
     "\n",
     "from openaivec.spark import EmbeddingsUDFBuilder\n",
     "\n",
-    "embeddings_udf = EmbeddingsUDFBuilder.of_openai(\n",
-    "    api_key=os.getenv(\"OPENAI_API_KEY\"),\n",
-    "    model_name=\"text-embedding-3-small\"\n",
-    ")\n",
+    "embeddings_udf = EmbeddingsUDFBuilder(model_name=\"text-embedding-3-small\")\n",
     "\n",
     "spark.udf.register(\"embed\", embeddings_udf.build(batch_size=1024))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[Stage 8:===============================>                          (6 + 5) / 11]\r"
+      "[Stage 8:===================================================>     (10 + 1) / 11]\r"
      ]
     },
     {
@@ -234,13 +234,13 @@
       "+----------+--------------------+\n",
       "|      name|           embedding|\n",
       "+----------+--------------------+\n",
-      "|     apple|[0.01764064, -0.0...|\n",
+      "|     apple|[0.01763439, -0.0...|\n",
       "|    banana|[0.013411593, -0....|\n",
-      "|    cherry|[0.036218576, -0....|\n",
-      "|     mango|[0.055494547, -0....|\n",
+      "|    cherry|[0.036222804, -0....|\n",
+      "|     mango|[0.055474974, -0....|\n",
       "|    orange|[-0.025922043, -0...|\n",
       "|     peach|[0.030673496, -0....|\n",
-      "|      pear|[0.023718908, -0....|\n",
+      "|      pear|[0.023664422, -0....|\n",
       "| pineapple|[0.020983547, -0....|\n",
       "|      plum|[0.0049052937, 6....|\n",
       "|strawberry|[0.020106195, -0....|\n",
@@ -277,23 +277,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "25/05/05 23:15:38 WARN SimpleFunctionRegistry: The function translate replaced a previously registered function.\n"
+      "25/08/05 06:46:09 WARN SimpleFunctionRegistry: The function translate replaced a previously registered function.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<pyspark.sql.udf.UserDefinedFunction at 0x10b203610>"
+       "<pyspark.sql.udf.UserDefinedFunction at 0x126720dd0>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -305,10 +305,7 @@
     "from openaivec.spark import ResponsesUDFBuilder\n",
     "from pydantic import BaseModel\n",
     "\n",
-    "udf = ResponsesUDFBuilder.of_openai(\n",
-    "    api_key=os.getenv(\"OPENAI_API_KEY\"),\n",
-    "    model_name=\"gpt-4.1-nano\",\n",
-    ")\n",
+    "udf = ResponsesUDFBuilder(model_name=\"gpt-4.1-nano\",)\n",
     "\n",
     "class Translation(BaseModel):\n",
     "    en: str\n",
@@ -328,30 +325,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "The model name 'gpt-4.1-nano' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.\n",
-      "[Stage 11:==================================================>     (10 + 1) / 11]\r"
+      "[Stage 11:==============================================>          (9 + 2) / 11]\r"
      ]
     },
     {
@@ -365,10 +346,10 @@
       "|    banana|   {banana, banane, ...|    banana|banane|      バナナ|plátano|  Banane|  banana| banana|   банан|\n",
       "|    cherry|   {cherry, cerise, ...|    cherry|cerise|  さくらんぼ| cereza| Kirsche|ciliegia| cereja|   вишня|\n",
       "|     mango|  {mango, mangue, マ...|     mango|mangue|    マンゴー|  mango|   Mango|   mango|  manga|   манго|\n",
-      "|    orange|   {orange, orange, ...|    orange|orange|    オレンジ|naranja|  orange| arancia|laranja|апельсин|\n",
+      "|    orange|   {orange, orange, ...|    orange|orange|    オレンジ|naranja|  Orange| arancia|laranja|апельсин|\n",
       "|     peach| {peach, pêche, もも...|     peach| pêche|        もも|durazno|Pfirsich|   pesca|pêssego|  персик|\n",
       "|      pear|  {pear, poire, 梨, ...|      pear| poire|          梨|   pera|   Birne|    pera|   pêra|   груша|\n",
-      "| pineapple|   {pineapple, anana...| pineapple|ananas|パイナップル|   piña|  Ananas|  ananas|abacaxi|  ананас|\n",
+      "| pineapple|   {Pineapple, Anana...| Pineapple|Ananas|パイナップル|   Piña|  Ananas|  Ananas|Abacaxi|  Ананас|\n",
       "|      plum|{plum, prune, プラム...|      plum| prune|      プラム|ciruela| Pflaume|  prugna| ameixa|   слива|\n",
       "|strawberry|   {strawberry, frai...|strawberry|fraise|      イチゴ|  fresa|Erdbeere| fragola|morango|клубника|\n",
       "+----------+-----------------------+----------+------+------------+-------+--------+--------+-------+--------+\n",
@@ -413,7 +394,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "openaivec (3.13.3)",
    "language": "python",
    "name": "python3"
   },
@@ -427,7 +408,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.17"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -18,14 +18,8 @@ from openaivec.task import nlp
 
 class TestUDFBuilder(TestCase):
     def setUp(self):
-        self.responses = ResponsesUDFBuilder.of_openai(
-            api_key=os.environ.get("OPENAI_API_KEY"),
-            model_name="gpt-4.1-nano",
-        )
-        self.embeddings = EmbeddingsUDFBuilder.of_openai(
-            api_key=os.environ.get("OPENAI_API_KEY"),
-            model_name="text-embedding-3-small",
-        )
+        self.responses = ResponsesUDFBuilder(model_name="gpt-4.1-nano")
+        self.embeddings = EmbeddingsUDFBuilder(model_name="text-embedding-3-small")
         self.spark: SparkSession = SparkSession.builder \
             .appName("TestSparkUDF") \
             .master("local[*]") \


### PR DESCRIPTION
This pull request updates the Spark integration to simplify authentication and usage patterns for OpenAI and Azure OpenAI models. The main change is moving authentication from UDF builder instantiation to SparkContext environment variables, making the API easier to use and more consistent with Spark best practices. The documentation and example notebooks are updated accordingly, and related helper methods and parameters are removed from the codebase.

**Authentication and API usage simplification:**

* Authentication for OpenAI and Azure OpenAI is now configured via `sc.environment` on the SparkContext, rather than passing keys to UDF builder constructors. The documentation and code comments have been updated to reflect this new pattern. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL12-R39) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL253-L300)
* The `of_openai` and `of_azure_openai` class methods and authentication parameters have been removed from `ResponsesUDFBuilder` and `EmbeddingsUDFBuilder`. Builders are now instantiated with just the model name. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL253-L300) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL151-L169)
* The `_initialize` helper function, which set environment variables for authentication, has been removed, and all calls to it in UDFs have been deleted. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL151-L169) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL346) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL368) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL441)

**Documentation and example updates:**

* The Spark example notebook (`docs/examples/spark.ipynb`) is updated to match the new authentication pattern, removing API key parameters from builder instantiation and setting environment variables via the SparkContext. Output and metadata are also refreshed. [[1]](diffhunk://#diff-7e46fd7afa826a5e835562860dcb6de4b1f1f12dbb9d3309262c137b09e82154L21-R36) [[2]](diffhunk://#diff-7e46fd7afa826a5e835562860dcb6de4b1f1f12dbb9d3309262c137b09e82154L210-R227) [[3]](diffhunk://#diff-7e46fd7afa826a5e835562860dcb6de4b1f1f12dbb9d3309262c137b09e82154L308-R308)
* The main Spark integration documentation (`src/openaivec/spark.py`) is rewritten to guide users through the new authentication approach and simplified builder usage. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL12-R39) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL253-L300)

These changes streamline the developer experience and reduce the risk of leaking credentials in code.