### PR TITLE
Feature/simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ from openaivec import BatchResponses
 # Initialize the batch client
 client = BatchResponses(
     client=OpenAI(),
-    model_name="gpt-4o-mini",
+    model_name="gpt-4.1-mini",
     system_message="Please answer only with 'xx family' and do not output anything else."
 )
 
@@ -147,7 +147,7 @@ import pandas as pd
 from openaivec import pandas_ext
 
 # Setup (optional - uses OPENAI_API_KEY environment variable by default)
-pandas_ext.responses_model("gpt-4o-mini")
+pandas_ext.responses_model("gpt-4.1-mini")
 
 # Create your data
 df = pd.DataFrame({"name": ["panda", "rabbit", "koala"]})
@@ -222,7 +222,7 @@ import pandas as pd
 from openaivec import pandas_ext
 
 # Setup (same as synchronous version)
-pandas_ext.responses_model("gpt-4o-mini")
+pandas_ext.responses_model("gpt-4.1-mini")
 
 df = pd.DataFrame({"text": [
     "This product is amazing!",

--- a/docs/examples/customer_analysis.ipynb
+++ b/docs/examples/customer_analysis.ipynb
@@ -21,7 +21,7 @@
     "from typing import Literal\n",
     "\n",
     "# Setup\n",
-    "pandas_ext.responses_model(\"gpt-4o-mini\")"
+    "pandas_ext.responses_model(\"gpt-4.1-mini\")"
    ]
   },
   {

--- a/docs/examples/prompt.ipynb
+++ b/docs/examples/prompt.ipynb
@@ -246,7 +246,7 @@
     "    .example(\"Banana\", Fruit(name=\"Banana\", color=\"Yellow\"))\n",
     "    .example(\"Strawberry\", Fruit(name=\"Strawberry\", color=\"Red\"))\n",
     "    .example(\"Blueberry\", Fruit(name=\"Blueberry\", color=\"Blue\"))\n",
-    "    .improve(client=client, model_name=\"gpt-4o-mini\")\n",
+    "    .improve(client=client, model_name=\"gpt-4.1-mini\")\n",
     "    .explain()\n",
     "    .build()\n",
     ")"

--- a/docs/examples/spark.ipynb
+++ b/docs/examples/spark.ipynb
@@ -190,30 +190,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<pyspark.sql.udf.UserDefinedFunction at 0x126701e00>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Register UDF to generate embeddings\n",
-    "import os\n",
-    "\n",
-    "from openaivec.spark import EmbeddingsUDFBuilder\n",
-    "\n",
-    "embeddings_udf = EmbeddingsUDFBuilder(model_name=\"text-embedding-3-small\")\n",
-    "\n",
-    "spark.udf.register(\"embed\", embeddings_udf.build(batch_size=1024))"
-   ]
+   "outputs": [],
+   "source": "# Register UDF to generate embeddings\nimport os\n\nfrom openaivec.spark import embeddings_udf\n\nspark.udf.register(\"embed\", embeddings_udf(model_name=\"text-embedding-3-small\", batch_size=1024))"
   },
   {
    "cell_type": "code",
@@ -277,51 +257,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "25/08/05 06:46:09 WARN SimpleFunctionRegistry: The function translate replaced a previously registered function.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<pyspark.sql.udf.UserDefinedFunction at 0x126720dd0>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Register UDF for multilingual translation\n",
-    "import os\n",
-    "\n",
-    "from openaivec.spark import ResponsesUDFBuilder\n",
-    "from pydantic import BaseModel\n",
-    "\n",
-    "udf = ResponsesUDFBuilder(model_name=\"gpt-4.1-nano\",)\n",
-    "\n",
-    "class Translation(BaseModel):\n",
-    "    en: str\n",
-    "    fr: str\n",
-    "    ja: str\n",
-    "    es: str\n",
-    "    de: str\n",
-    "    it: str\n",
-    "    pt: str\n",
-    "    ru: str\n",
-    "\n",
-    "spark.udf.register(\"translate\", udf.build(\n",
-    "    instructions=\"Translate the following text to English, French, Japanese, Spanish, German, Italian, Portuguese, and Russian.\",\n",
-    "    response_format=Translation,\n",
-    "))"
-   ]
+   "outputs": [],
+   "source": "# Register UDF for multilingual translation\nimport os\n\nfrom openaivec.spark import responses_udf\nfrom pydantic import BaseModel\n\nclass Translation(BaseModel):\n    en: str\n    fr: str\n    ja: str\n    es: str\n    de: str\n    it: str\n    pt: str\n    ru: str\n\nspark.udf.register(\"translate\", responses_udf(\n    instructions=\"Translate the following text to English, French, Japanese, Spanish, German, Italian, Portuguese, and Russian.\",\n    response_format=Translation,\n    model_name=\"gpt-4.1-nano\"\n))"
   },
   {
    "cell_type": "code",

--- a/docs/examples/survey_transformation.ipynb
+++ b/docs/examples/survey_transformation.ipynb
@@ -20,7 +20,7 @@
     "from pydantic import BaseModel\n",
     "from typing import List, Optional\n",
     "\n",
-    "pandas_ext.responses_model(\"gpt-4o-mini\")"
+    "pandas_ext.responses_model(\"gpt-4.1-mini\")"
    ]
   },
   {

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -27,7 +27,7 @@ async_client = AsyncOpenAI(api_key="your-api-key")
 pandas_ext.use_async(async_client)
 
 # Set up model names (optional, defaults shown)
-pandas_ext.responses_model("gpt-4o-mini")
+pandas_ext.responses_model("gpt-4.1-mini")
 pandas_ext.embeddings_model("text-embedding-3-small")
 ```
 
@@ -68,7 +68,7 @@ T = TypeVar("T")
 _DI = Container()
 _DI.register(OpenAI, provide_openai_client)
 _DI.register(AsyncOpenAI, provide_async_openai_client)
-_DI.register(ResponsesModelName, lambda: ResponsesModelName("gpt-4o-mini"))
+_DI.register(ResponsesModelName, lambda: ResponsesModelName("gpt-4.1-mini"))
 _DI.register(EmbeddingsModelName, lambda: EmbeddingsModelName("text-embedding-3-small"))
 
 
@@ -114,7 +114,7 @@ def responses_model(name: str) -> None:
 
     Args:
         name (str): Model name as listed in the OpenAI API
-            (for example, ``gpt-4o-mini``).
+            (for example, ``gpt-4.1-mini``).
     """
     _DI.register(ResponsesModelName, lambda: ResponsesModelName(name))
     _DI.register(tiktoken.Encoding, _provide_tiktoken_encoding)
@@ -178,7 +178,7 @@ class OpenAIVecSeriesAccessor:
             This method returns a Series of strings, each containing the
             assistant's response to the corresponding input.
             The model used is set by the `responses_model` function.
-            The default model is `gpt-4o-mini`.
+            The default model is `gpt-4.1-mini`.
 
         Args:
             instructions (str): System prompt prepended to every user message.
@@ -388,7 +388,7 @@ class OpenAIVecDataFrameAccessor:
             assistant's response to the corresponding input.
             Each row is serialised to JSON before being sent to the assistant.
             The model used is set by the `responses_model` function.
-            The default model is `gpt-4o-mini`.
+            The default model is `gpt-4.1-mini`.
 
         Args:
             instructions (str): System prompt for the assistant.
@@ -552,7 +552,7 @@ class AsyncOpenAIVecSeriesAccessor:
             This method returns a Series of strings, each containing the
             assistant's response to the corresponding input.
             The model used is set by the `responses_model` function.
-            The default model is `gpt-4o-mini`.
+            The default model is `gpt-4.1-mini`.
 
         Args:
             instructions (str): System prompt prepended to every user message.
@@ -717,7 +717,7 @@ class AsyncOpenAIVecDataFrameAccessor:
             assistant's response to the corresponding input.
             Each row is serialised to JSON before being sent to the assistant.
             The model used is set by the `responses_model` function.
-            The default model is `gpt-4o-mini`.
+            The default model is `gpt-4.1-mini`.
 
         Args:
             instructions (str): System prompt for the assistant.

--- a/src/openaivec/prompt.py
+++ b/src/openaivec/prompt.py
@@ -421,7 +421,7 @@ class FewShotPromptBuilder:
 
         Args:
             client (openai.OpenAI): Configured OpenAI client.
-            model_name (str): Model identifier (e.g. ``gpt-4o-mini``).
+            model_name (str): Model identifier (e.g. ``gpt-4.1-mini``).
             temperature (float, optional): Sampling temperature. Defaults to 0.0.
             top_p (float, optional): Nucleus sampling parameter. Defaults to 1.0.
 

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -253,7 +253,7 @@ class AsyncBatchResponses(Generic[T]):
 
         vector_llm = AsyncBatchResponses(
             client=openai_async_client,
-            model_name="gpt-4o-mini",
+            model_name="gpt-4.1-mini",
             system_message="You are a helpful assistant.",
             max_concurrency=5  # Limit concurrent requests
         )

--- a/src/openaivec/task/__init__.py
+++ b/src/openaivec/task/__init__.py
@@ -40,13 +40,13 @@ client = OpenAI()
 # Use pre-configured tasks
 sentiment_analyzer = BatchResponses.of_task(
     client=client,
-    model_name="gpt-4o-mini",
+    model_name="gpt-4.1-mini",
     task=nlp.SENTIMENT_ANALYSIS
 )
 
 intent_analyzer = BatchResponses.of_task(
     client=client,
-    model_name="gpt-4o-mini",
+    model_name="gpt-4.1-mini",
     task=customer_support.INTENT_ANALYSIS
 )
 ```
@@ -68,7 +68,7 @@ custom_urgency = urgency_analysis(
 
 analyzer = BatchResponses.of_task(
     client=client,
-    model_name="gpt-4o-mini",
+    model_name="gpt-4.1-mini",
     task=custom_urgency
 )
 ```
@@ -97,7 +97,7 @@ spark.udf.register(
     "analyze_sentiment",
     ResponsesUDFBuilder.of_openai(
         api_key=api_key,
-        model_name="gpt-4o-mini"
+        model_name="gpt-4.1-mini"
     ).build_from_task(task=nlp.SENTIMENT_ANALYSIS)
 )
 
@@ -165,7 +165,7 @@ src/openaivec/task/finance/
 ## Best Practices
 
 1. **Choose Appropriate Models**:
-   - `gpt-4o-mini`: Fast, cost-effective for most tasks
+   - `gpt-4.1-mini`: Fast, cost-effective for most tasks
    - `gpt-4o`: Higher accuracy for complex analysis
 
 2. **Customize When Needed**:

--- a/src/openaivec/task/customer_support/customer_sentiment.py
+++ b/src/openaivec/task/customer_support/customer_sentiment.py
@@ -15,7 +15,7 @@ Example:
     client = OpenAI()
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=customer_support.CUSTOMER_SENTIMENT
     )
 

--- a/src/openaivec/task/customer_support/inquiry_classification.py
+++ b/src/openaivec/task/customer_support/inquiry_classification.py
@@ -14,7 +14,7 @@ Example:
     client = OpenAI()
     classifier = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=customer_support.inquiry_classification()
     )
 
@@ -64,7 +64,7 @@ Example:
 
     classifier = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=task
     )
     ```

--- a/src/openaivec/task/customer_support/inquiry_summary.py
+++ b/src/openaivec/task/customer_support/inquiry_summary.py
@@ -15,7 +15,7 @@ Example:
     client = OpenAI()
     summarizer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=customer_support.INQUIRY_SUMMARY
     )
 

--- a/src/openaivec/task/customer_support/intent_analysis.py
+++ b/src/openaivec/task/customer_support/intent_analysis.py
@@ -14,7 +14,7 @@ Example:
     client = OpenAI()
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=customer_support.INTENT_ANALYSIS
     )
 

--- a/src/openaivec/task/customer_support/response_suggestion.py
+++ b/src/openaivec/task/customer_support/response_suggestion.py
@@ -15,7 +15,7 @@ Example:
     client = OpenAI()
     responder = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=customer_support.RESPONSE_SUGGESTION
     )
 

--- a/src/openaivec/task/customer_support/urgency_analysis.py
+++ b/src/openaivec/task/customer_support/urgency_analysis.py
@@ -14,7 +14,7 @@ Example:
     client = OpenAI()
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=customer_support.urgency_analysis()
     )
 
@@ -71,7 +71,7 @@ Example:
 
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=task
     )
     ```

--- a/src/openaivec/task/nlp/dependency_parsing.py
+++ b/src/openaivec/task/nlp/dependency_parsing.py
@@ -14,7 +14,7 @@ Example:
     client = OpenAI()
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=nlp.DEPENDENCY_PARSING
     )
 

--- a/src/openaivec/task/nlp/keyword_extraction.py
+++ b/src/openaivec/task/nlp/keyword_extraction.py
@@ -14,7 +14,7 @@ Example:
     client = OpenAI()
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=nlp.KEYWORD_EXTRACTION
     )
 

--- a/src/openaivec/task/nlp/morphological_analysis.py
+++ b/src/openaivec/task/nlp/morphological_analysis.py
@@ -15,7 +15,7 @@ Example:
     client = OpenAI()
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=nlp.MORPHOLOGICAL_ANALYSIS
     )
 

--- a/src/openaivec/task/nlp/named_entity_recognition.py
+++ b/src/openaivec/task/nlp/named_entity_recognition.py
@@ -14,7 +14,7 @@ Example:
     client = OpenAI()
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=nlp.NAMED_ENTITY_RECOGNITION
     )
 

--- a/src/openaivec/task/nlp/sentiment_analysis.py
+++ b/src/openaivec/task/nlp/sentiment_analysis.py
@@ -14,7 +14,7 @@ Example:
     client = OpenAI()
     analyzer = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=nlp.SENTIMENT_ANALYSIS
     )
 

--- a/src/openaivec/task/nlp/translation.py
+++ b/src/openaivec/task/nlp/translation.py
@@ -19,7 +19,7 @@ Example:
     client = OpenAI()
     translator = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=nlp.MULTILINGUAL_TRANSLATION
     )
 

--- a/src/openaivec/task/table/fillna.py
+++ b/src/openaivec/task/table/fillna.py
@@ -48,7 +48,7 @@ Example:
     # Process with BatchResponses
     filler = BatchResponses.of_task(
         client=client,
-        model_name="gpt-4o-mini",
+        model_name="gpt-4.1-mini",
         task=task
     )
 

--- a/tests/test_pandas_ext.py
+++ b/tests/test_pandas_ext.py
@@ -10,7 +10,7 @@ from openaivec import pandas_ext
 
 pandas_ext.use(OpenAI())
 pandas_ext.use_async(AsyncOpenAI())
-pandas_ext.responses_model("gpt-4o-mini")
+pandas_ext.responses_model("gpt-4.1-mini")
 pandas_ext.embeddings_model("text-embedding-3-small")
 
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -17,7 +17,7 @@ basicConfig(handlers=[_h], level="DEBUG")
 class TestVectorizedResponsesOpenAI(TestCase):
     def setUp(self):
         self.openai_client = OpenAI()
-        self.model_name = "gpt-4o-mini"
+        self.model_name = "gpt-4.1-mini"
 
     def test_predict_str(self):
         system_message = """


### PR DESCRIPTION
This pull request updates the default and example model names throughout the codebase and documentation from `gpt-4o-mini` to `gpt-4.1-mini`, and refactors the Spark UDF API to use new functional interfaces instead of builder classes. The documentation, code examples, and internal defaults are all updated for consistency and clarity, making it easier for users to adopt the latest model and the new Spark API.

**Model name updates:**

* Changed default and example model names from `gpt-4o-mini` to `gpt-4.1-mini` in `README.md`, `src/openaivec/pandas_ext.py`, `src/openaivec/prompt.py`, `src/openaivec/responses.py`, and all example notebooks. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L131-R131) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L150-R150) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L225-R225) [[4]](diffhunk://#diff-cf33d966dc1f14d35a835be619da5230b81caffad2c1b2e2e02d0714ad228450L24-R24) [[5]](diffhunk://#diff-23447c8c6c321d8e3882bb23f0f5104030262b3cd26362fc9261d3909a68f658L249-R249) [[6]](diffhunk://#diff-330cb046768b78d83ae9893e7a9199b9860522e4dce49a5180e1d78a6eb02b9cL23-R23) [[7]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L30-R30) [[8]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L71-R71) [[9]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L117-R117) [[10]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L181-R181) [[11]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L391-R391) [[12]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L555-R555) [[13]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L720-R720) [[14]](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL424-R424) [[15]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL256-R256)

**Spark UDF API refactor:**

* Replaced builder classes (`ResponsesUDFBuilder`, `EmbeddingsUDFBuilder`) with functional interfaces (`responses_udf`, `responses_udf_from_task`, `embeddings_udf`) in `src/openaivec/spark.py` and all documentation and example usages. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL3-R3) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL31-L40) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL50-R66) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL126-R125) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L283-R295) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L312-R312) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L323-R322) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L337-R348) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L616-R622) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L631-R639) [[11]](diffhunk://#diff-7e46fd7afa826a5e835562860dcb6de4b1f1f12dbb9d3309262c137b09e82154L193-R196) [[12]](diffhunk://#diff-7e46fd7afa826a5e835562860dcb6de4b1f1f12dbb9d3309262c137b09e82154L280-R263)

**Documentation and example updates:**

* Updated all code snippets and explanations in `README.md`, example notebooks, and module docstrings to use the new model name and Spark UDF API. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL31-L40) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL50-R66) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L283-R295) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L312-R312) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L323-R322) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L337-R348) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L616-R622) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L631-R639) [[9]](diffhunk://#diff-7e46fd7afa826a5e835562860dcb6de4b1f1f12dbb9d3309262c137b09e82154L193-R196) [[10]](diffhunk://#diff-7e46fd7afa826a5e835562860dcb6de4b1f1f12dbb9d3309262c137b09e82154L280-R263)

**Code cleanup:**

* Removed unused imports and references to builder classes in `src/openaivec/spark.py`. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL108) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL126-R125)

These changes ensure users are guided to use the latest recommended model and the simplified Spark API, improving both usability and maintainability.