### PR TITLE
Refactor/task

### DIFF
--- a/src/openaivec/model.py
+++ b/src/openaivec/model.py
@@ -52,7 +52,7 @@ class PreparedTask:
     """
 
     instructions: str
-    response_format: Type[T]
+    response_format: Type[T] | Type[str]
     temperature: float = 0.0
     top_p: float = 1.0
 

--- a/src/openaivec/model.py
+++ b/src/openaivec/model.py
@@ -3,7 +3,7 @@ from typing import Type, TypeVar
 
 from pydantic import BaseModel
 
-T = TypeVar("T", bound=BaseModel)
+ResponseFormat = TypeVar("ResponseFormat", bound=BaseModel | str)
 
 
 @dataclass(frozen=True)
@@ -18,8 +18,8 @@ class PreparedTask:
     Attributes:
         instructions (str): The prompt or instructions to send to the OpenAI model.
             This should contain clear, specific directions for the task.
-        response_format (Type[T]): A Pydantic model class that defines the expected
-            structure of the response. Must inherit from BaseModel.
+        response_format (Type[ResponseFormat]): A Pydantic model class or str type that defines the expected
+            structure of the response. Can be either a BaseModel subclass or str.
         temperature (float): Controls randomness in the model's output.
             Range: 0.0 to 1.0. Lower values make output more deterministic.
             Defaults to 0.0.
@@ -52,7 +52,7 @@ class PreparedTask:
     """
 
     instructions: str
-    response_format: Type[T] | Type[str]
+    response_format: Type[ResponseFormat]
     temperature: float = 0.0
     top_p: float = 1.0
 

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -48,7 +48,7 @@ from pydantic import BaseModel
 
 from .di import Container
 from .embeddings import AsyncBatchEmbeddings, BatchEmbeddings
-from .model import EmbeddingsModelName, PreparedTask, ResponsesModelName
+from .model import EmbeddingsModelName, PreparedTask, ResponseFormat, ResponsesModelName
 from .provider import provide_async_openai_client, provide_openai_client
 from .responses import AsyncBatchResponses, BatchResponses
 from .task.table import FillNaResponse, fillna
@@ -63,7 +63,7 @@ __all__ = [
 _LOGGER = logging.getLogger(__name__)
 
 
-T = TypeVar("T")
+T = TypeVar("T")  # For pipe function return type
 
 _DI = Container()
 _DI.register(OpenAI, provide_openai_client)
@@ -163,7 +163,7 @@ class OpenAIVecSeriesAccessor:
     def responses(
         self,
         instructions: str,
-        response_format: Type[T] = str,
+        response_format: Type[ResponseFormat] = str,
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
@@ -182,7 +182,7 @@ class OpenAIVecSeriesAccessor:
 
         Args:
             instructions (str): System prompt prepended to every user message.
-            response_format (Type[T], optional): Pydantic model or built‑in
+            response_format (Type[ResponseFormat], optional): Pydantic model or built‑in
                 type the assistant should return. Defaults to ``str``.
             batch_size (int, optional): Number of prompts grouped into a single
                 request. Defaults to ``128``.
@@ -368,7 +368,7 @@ class OpenAIVecDataFrameAccessor:
     def responses(
         self,
         instructions: str,
-        response_format: Type[T] = str,
+        response_format: Type[ResponseFormat] = str,
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
@@ -392,7 +392,7 @@ class OpenAIVecDataFrameAccessor:
 
         Args:
             instructions (str): System prompt for the assistant.
-            response_format (Type[T], optional): Desired Python type of the
+            response_format (Type[ResponseFormat], optional): Desired Python type of the
                 responses. Defaults to ``str``.
             batch_size (int, optional): Number of requests sent in one batch.
                 Defaults to ``128``.
@@ -535,7 +535,7 @@ class AsyncOpenAIVecSeriesAccessor:
     async def responses(
         self,
         instructions: str,
-        response_format: Type[T] = str,
+        response_format: Type[ResponseFormat] = str,
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
@@ -556,7 +556,7 @@ class AsyncOpenAIVecSeriesAccessor:
 
         Args:
             instructions (str): System prompt prepended to every user message.
-            response_format (Type[T], optional): Pydantic model or built‑in
+            response_format (Type[ResponseFormat], optional): Pydantic model or built‑in
                 type the assistant should return. Defaults to ``str``.
             batch_size (int, optional): Number of prompts grouped into a single
                 request. Defaults to ``128``.
@@ -695,7 +695,7 @@ class AsyncOpenAIVecDataFrameAccessor:
     async def responses(
         self,
         instructions: str,
-        response_format: Type[T] = str,
+        response_format: Type[ResponseFormat] = str,
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
@@ -721,7 +721,7 @@ class AsyncOpenAIVecDataFrameAccessor:
 
         Args:
             instructions (str): System prompt for the assistant.
-            response_format (Type[T], optional): Desired Python type of the
+            response_format (Type[ResponseFormat], optional): Desired Python type of the
                 responses. Defaults to ``str``.
             batch_size (int, optional): Number of requests sent in one batch.
                 Defaults to ``128``.

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -123,7 +123,7 @@ class BatchResponses(Generic[ResponseFormat]):
         system_message: System prompt prepended to every request.
         temperature: Sampling temperature passed to the model.
         top_p: Nucleus‑sampling parameter.
-        response_format: Expected Pydantic type of each assistant message
+        response_format: Expected Pydantic BaseModel subclass or str type for each assistant message
             (defaults to ``str``).
 
     Notes:
@@ -272,7 +272,7 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         system_message: System prompt prepended to every request.
         temperature: Sampling temperature passed to the model.
         top_p: Nucleus-sampling parameter.
-        response_format: Expected Pydantic type of each assistant message
+        response_format: Expected Pydantic BaseModel subclass or str type for each assistant message
             (defaults to `str`).
         max_concurrency: Maximum number of concurrent requests to the OpenAI API.
     """

--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -104,7 +104,7 @@ Note: This module provides asynchronous support through the pandas extensions.
 import asyncio
 import logging
 from enum import Enum
-from typing import Dict, Iterator, List, Optional, Type, TypeVar, Union, get_args, get_origin
+from typing import Dict, Iterator, List, Optional, Type, Union, get_args, get_origin
 
 import pandas as pd
 import tiktoken
@@ -115,7 +115,7 @@ from pyspark.sql.udf import UserDefinedFunction
 from typing_extensions import Literal
 
 from . import pandas_ext
-from .model import PreparedTask
+from .model import PreparedTask, ResponseFormat
 from .serialize import deserialize_base_model, serialize_base_model
 from .util import TextChunker
 
@@ -128,7 +128,6 @@ __all__ = [
     "similarity_udf",
 ]
 
-T = TypeVar("T", bound=BaseModel)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 _TIKTOKEN_ENC: tiktoken.Encoding | None = None
@@ -213,7 +212,7 @@ def _safe_dump(x: Optional[BaseModel]) -> Dict:
 
 def responses_udf(
     instructions: str,
-    response_format: Type[T] = str,
+    response_format: Type[ResponseFormat] = str,
     model_name: str = "gpt-4.1-mini",
     batch_size: int = 128,
     temperature: float = 0.0,
@@ -239,7 +238,7 @@ def responses_udf(
 
     Args:
         instructions (str): The system prompt or instructions for the model.
-        response_format (Type[T]): The desired output format. Either `str` for plain text
+        response_format (Type[ResponseFormat]): The desired output format. Either `str` for plain text
             or a Pydantic `BaseModel` for structured JSON output. Defaults to `str`.
         model_name (str): Deployment name (Azure) or model name (OpenAI) for responses.
             Defaults to "gpt-4.1-mini".

--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -1,6 +1,6 @@
 """Asynchronous Spark UDFs for the OpenAI and Azure OpenAI APIs.
 
-This module provides functions (`responses_udf`, `responses_udf_from_task`, `embeddings_udf`)
+This module provides functions (`responses_udf`, `task_udf`, `embeddings_udf`)
 for creating asynchronous Spark UDFs that communicate with either the public
 OpenAI API or Azure OpenAI using the `openaivec.spark` subpackage.
 It supports UDFs for generating responses and creating embeddings asynchronously.
@@ -31,7 +31,7 @@ sc.environment["OPENAI_API_KEY"] = "your-openai-api-key"
 Next, create UDFs and register them:
 
 ```python
-from openaivec.spark import responses_udf, responses_udf_from_task, embeddings_udf
+from openaivec.spark import responses_udf, task_udf, embeddings_udf
 from pydantic import BaseModel
 
 # Define a Pydantic model for structured responses (optional)
@@ -52,11 +52,11 @@ spark.udf.register(
     ),
 )
 
-# Or use a predefined task with responses_udf_from_task
+# Or use a predefined task with task_udf
 from openaivec.task import nlp
 spark.udf.register(
     "sentiment_async",
-    responses_udf_from_task(nlp.SENTIMENT_ANALYSIS),
+    task_udf(nlp.SENTIMENT_ANALYSIS),
 )
 
 # Register the asynchronous embeddings UDF with performance tuning
@@ -121,7 +121,7 @@ from .util import TextChunker
 
 __all__ = [
     "responses_udf",
-    "responses_udf_from_task",
+    "task_udf",
     "embeddings_udf",
     "split_to_chunks_udf",
     "count_tokens_udf",
@@ -315,7 +315,7 @@ def responses_udf(
 
 
 
-def responses_udf_from_task(
+def task_udf(
     task: PreparedTask,
     model_name: str = "gpt-4.1-mini",
     batch_size: int = 128,
@@ -348,7 +348,7 @@ def responses_udf_from_task(
         ```python
         from openaivec.task import nlp
 
-        sentiment_udf = responses_udf_from_task(nlp.SENTIMENT_ANALYSIS)
+        sentiment_udf = task_udf(nlp.SENTIMENT_ANALYSIS)
 
         spark.udf.register("analyze_sentiment", sentiment_udf)
         ```

--- a/src/openaivec/task/__init__.py
+++ b/src/openaivec/task/__init__.py
@@ -117,7 +117,7 @@ All tasks are built using the `PreparedTask` dataclass:
 @dataclass(frozen=True)
 class PreparedTask:
     instructions: str           # Detailed prompt for the LLM
-    response_format: Type[T]    # Pydantic model for structured output
+    response_format: Type[ResponseFormat]    # Pydantic model or str for structured/plain output
     temperature: float = 0.0    # Sampling temperature
     top_p: float = 1.0         # Nucleus sampling parameter
 ```
@@ -183,8 +183,4 @@ src/openaivec/task/finance/
 See individual task modules for detailed documentation and examples.
 """
 
-from ..model import PreparedTask
-
-__all__ = [
-    "PreparedTask",
-]
+__all__ = []


### PR DESCRIPTION
This pull request refactors the type system for response formats throughout the codebase to improve flexibility and clarity. The main change is the introduction of a new `ResponseFormat` type variable, which allows response formats to be either a Pydantic `BaseModel` subclass or a plain `str`. This update ensures that all relevant APIs and classes consistently support both structured and unstructured response types. Additionally, the Spark UDF documentation and imports are updated for clarity.

**Type system improvements for response formats:**

* Introduced `ResponseFormat` as a `TypeVar` bound to `BaseModel | str` in `model.py`, replacing the previous `T` which was limited to `BaseModel`. This allows response formats to be either structured (Pydantic models) or unstructured (`str`).
* Updated the `PreparedTask` class and related docstrings to use `ResponseFormat`, clarifying that `response_format` can be a Pydantic model or a string. [[1]](diffhunk://#diff-cff4c2db8158c67c12389829e98df72456ded2aa36723ffcc93408d83744f374L21-R22) [[2]](diffhunk://#diff-cff4c2db8158c67c12389829e98df72456ded2aa36723ffcc93408d83744f374L55-R55)
* Changed all relevant method signatures and generics in `pandas_ext.py` (e.g., `responses` methods) to use `ResponseFormat` instead of the previous generic `T`. [[1]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L51-R51) [[2]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L166-R166) [[3]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L185-R185) [[4]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L371-R371) [[5]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L395-R395) [[6]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L538-R538) [[7]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L559-R559) [[8]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L698-R698) [[9]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L724-R724)
* Refactored the `responses.py` module to use `ResponseFormat` throughout all classes and functions, including `BatchResponses`, `AsyncBatchResponses`, and related generics and docstrings. [[1]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL4-R11) [[2]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL88-R104) [[3]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL127-R126) [[4]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL142-R141) [[5]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL167-R166) [[6]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL176-R175) [[7]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL200-R202) [[8]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL216-R221) [[9]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL238-R237) [[10]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL276-R275) [[11]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL286-R285) [[12]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL319-R318) [[13]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL328-R327) [[14]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL355-R357) [[15]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL370-R376)

**Documentation and API clarity:**

* Updated Spark UDF documentation and imports to consistently use `task_udf` instead of the deprecated `responses_udf_from_task`, improving clarity for users. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL3-R3) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL34-R34) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL55-R59) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL107-R107)