### PR TITLE
chore: fix old function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ sc.environment["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY")
 Next, create and register UDFs using the provided functions:
 
 ```python
-from openaivec.spark import responses_udf, responses_udf_from_task, embeddings_udf, count_tokens_udf
+from openaivec.spark import responses_udf, task_udf, embeddings_udf, count_tokens_udf
 from pydantic import BaseModel
 
 # --- Register Responses UDF (String Output) ---
@@ -333,7 +333,7 @@ from openaivec.task import nlp, customer_support
 
 spark.udf.register(
     "analyze_sentiment",
-    responses_udf_from_task(
+    task_udf(
         task=nlp.SENTIMENT_ANALYSIS,
         model_name="gpt-4.1-mini",  # Optional, defaults to gpt-4.1-mini
         batch_size=64,
@@ -343,7 +343,7 @@ spark.udf.register(
 
 spark.udf.register(
     "classify_intent",
-    responses_udf_from_task(
+    task_udf(
         task=customer_support.INTENT_ANALYSIS,
         model_name="gpt-4.1-mini",  # Optional, defaults to gpt-4.1-mini
         batch_size=32,              # Smaller batches for complex analysis


### PR DESCRIPTION
This pull request updates the usage of UDF registration functions in the `README.md` to reflect recent API changes. The main change is replacing references to the deprecated `responses_udf_from_task` function with the new `task_udf` function, ensuring the documentation aligns with the current codebase.

**Documentation updates:**

* Replaced all imports and usages of the deprecated `responses_udf_from_task` with the new `task_udf` in the UDF registration examples in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L286-R286) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L336-R336) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L346-R346)