### PR TITLE
refactor: fix model for tiktoken

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ spark.udf.register(
 )
 
 # --- Register Token Counting UDF ---
-spark.udf.register("count_tokens", count_tokens_udf("gpt-4o"))
+spark.udf.register("count_tokens", count_tokens_udf())
 
 # --- Register UDFs with Pre-configured Tasks ---
 from openaivec.task import nlp, customer_support

--- a/docs/examples/spark.ipynb
+++ b/docs/examples/spark.ipynb
@@ -114,26 +114,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<pyspark.sql.udf.UserDefinedFunction at 0x1264d20d0>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Register UDF to count tokens using OpenAI GPT model\n",
-    "from openaivec.spark import count_tokens_udf\n",
-    "\n",
-    "spark.udf.register(\"count_tokens\", count_tokens_udf(\"gpt-4o\"))"
-   ]
+   "outputs": [],
+   "source": "# Register UDF to count tokens using OpenAI GPT model\nfrom openaivec.spark import count_tokens_udf\n\nspark.udf.register(\"count_tokens\", count_tokens_udf())"
   },
   {
    "cell_type": "code",

--- a/src/openaivec/provider.py
+++ b/src/openaivec/provider.py
@@ -12,6 +12,7 @@ from openaivec.model import (
     OpenAIAPIKey,
     ResponsesModelName,
 )
+from openaivec.util import TextChunker
 
 CONTAINER = di.Container()
 
@@ -76,6 +77,7 @@ CONTAINER.register(
 CONTAINER.register(OpenAI, provide_openai_client)
 CONTAINER.register(AsyncOpenAI, provide_async_openai_client)
 CONTAINER.register(tiktoken.Encoding, lambda: tiktoken.get_encoding("o200k_base"))
+CONTAINER.register(TextChunker, lambda: TextChunker(CONTAINER.resolve(tiktoken.Encoding)))
 
 
 def reset_environment_registrations():

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -186,7 +186,7 @@ class TestSparkUDFs(TestCase):
         """Test count_tokens_udf functionality."""
         self.spark.udf.register(
             "count_tokens",
-            count_tokens_udf("gpt-4o"),
+            count_tokens_udf(),
         )
 
         sentences = [


### PR DESCRIPTION
This pull request updates the Spark UDF utilities in `openaivec.spark` to simplify token counting and chunking functions, standardize tokenization to a specific encoding, and improve documentation and registration examples. The most significant changes are the removal of the `model_name` argument from `count_tokens_udf` and `split_to_chunks_udf`, which now use a fixed encoding, and the corresponding updates to documentation, usage, and tests.

**API simplification and standardization:**

* Removed the `model_name` argument from both `count_tokens_udf` and `split_to_chunks_udf`; both functions now use the `"o200k_base"` encoding by default, simplifying their interfaces and ensuring consistent tokenization. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL467-L471) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL482-R508)
* Updated all usages, examples, and tests to reflect the new API, removing the model name parameter in function calls and UDF registrations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L324-R324) [[2]](diffhunk://#diff-7e46fd7afa826a5e835562860dcb6de4b1f1f12dbb9d3309262c137b09e82154L117-R120) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR71-R74) [[4]](diffhunk://#diff-09cfb6f133292348c331f171e17cced53e5dd31dc6c777a92e2241837b253a25L189-R189)

**Documentation and code clarity:**

* Improved the module and docstring documentation for `openaivec.spark` to include the new UDFs (`count_tokens_udf`, `split_to_chunks_udf`) and updated example code to match the simplified API. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL3-R3) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL34-R34) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL80-R86)
* Cleaned up unused variables and redundant code related to tokenization, such as removing the global `_TIKTOKEN_ENC` and related logic.

**Dependency injection improvements:**

* Registered the `TextChunker` utility in the dependency injection container, ensuring it uses the standardized encoding. [[1]](diffhunk://#diff-49a0814cf54fdc2baa2a21c513a9e0a60ce2070a07978da5510270e21f399f00R15) [[2]](diffhunk://#diff-49a0814cf54fdc2baa2a21c513a9e0a60ce2070a07978da5510270e21f399f00R80)