### PR TITLE
Feature/proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,14 @@ from openai import OpenAI
 from openaivec import BatchResponses
 
 # Initialize the batch client
-client = BatchResponses(
+client = BatchResponses.of(
     client=OpenAI(),
     model_name="gpt-4.1-mini",
-    system_message="Please answer only with 'xx family' and do not output anything else."
+    system_message="Please answer only with 'xx family' and do not output anything else.",
+    batch_size=32,
 )
 
-result = client.parse(["panda", "rabbit", "koala"], batch_size=32)
+result = client.parse(["panda", "rabbit", "koala"])
 print(result)  # Expected output: ['bear family', 'rabbit family', 'koala family']
 ```
 

--- a/src/openaivec/embeddings.py
+++ b/src/openaivec/embeddings.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass, field
 from logging import Logger, getLogger
 from typing import List
@@ -7,8 +6,10 @@ import numpy as np
 from numpy.typing import NDArray
 from openai import AsyncOpenAI, OpenAI, RateLimitError
 
+from openaivec.proxy import AsyncBatchingMapProxy, BatchingMapProxy
+
 from .log import observe
-from .util import backoff, backoff_async, map, map_async
+from .util import backoff, backoff_async
 
 __all__ = [
     "BatchEmbeddings",
@@ -29,6 +30,12 @@ class BatchEmbeddings:
 
     client: OpenAI
     model_name: str
+    cache: BatchingMapProxy[str, NDArray[np.float32]] = field(default_factory=lambda: BatchingMapProxy(batch_size=128))
+
+    @classmethod
+    def of(cls, client: OpenAI, model_name: str, batch_size: int = 128) -> "BatchEmbeddings":
+        """Create a BatchEmbeddings instance configured with a batching proxy."""
+        return cls(client=client, model_name=model_name, cache=BatchingMapProxy(batch_size=batch_size))
 
     @observe(_LOGGER)
     @backoff(exception=RateLimitError, scale=15, max_retries=8)
@@ -50,26 +57,17 @@ class BatchEmbeddings:
         return [np.array(d.embedding, dtype=np.float32) for d in responses.data]
 
     @observe(_LOGGER)
-    def create(self, inputs: List[str], batch_size: int) -> List[NDArray[np.float32]]:
-        """See ``VectorizedEmbeddings.create`` for contract details.
-
-        The call is internally delegated to either ``map_unique_minibatch`` or
-        its parallel counterpart depending on *is_parallel*.
+    def create(self, inputs: List[str]) -> List[NDArray[np.float32]]:
+        """Generate embeddings for inputs using cached, ordered batching.
 
         Args:
             inputs (List[str]): A list of input strings. Duplicates are allowed; the
-                implementation may decide to de‑duplicate internally.
-            batch_size (int): Maximum number of sentences to be sent to the underlying
-                model in one request.
+                implementation may de‑duplicate internally.
 
         Returns:
-            A list of ``np.ndarray`` objects (dtype ``float32``) where each entry
-                is the embedding of the corresponding sentence in *sentences*.
-
-        Raises:
-            openai.RateLimitError: Propagated if retries are exhausted.
+            A list of ``np.ndarray`` objects (dtype ``float32``), aligned to inputs.
         """
-        return map(inputs, self._embed_chunk, batch_size)
+        return self.cache.map(inputs, self._embed_chunk)
 
 
 @dataclass(frozen=True)
@@ -85,21 +83,22 @@ class AsyncBatchEmbeddings:
         import asyncio
         import numpy as np
         from openai import AsyncOpenAI
-        from openaivec.aio.embeddings import AsyncBatchEmbeddings
+    from openaivec import AsyncBatchEmbeddings
 
         # Assuming openai_async_client is an initialized AsyncOpenAI client
         openai_async_client = AsyncOpenAI() # Replace with your actual client initialization
 
-        embedder = AsyncBatchEmbeddings(
+        embedder = AsyncBatchEmbeddings.of(
             client=openai_async_client,
             model_name="text-embedding-3-small",
-            max_concurrency=8  # Limit concurrent requests
+            batch_size=128,
+            max_concurrency=8,
         )
         texts = ["This is the first document.", "This is the second document.", "This is the first document."]
 
         # Asynchronous call
         async def main():
-            embeddings = await embedder.create(texts, batch_size=128)
+            embeddings = await embedder.create(texts)
             # embeddings will be a list of numpy arrays (float32)
             # The embedding for the third text will be identical to the first
             # due to automatic de-duplication.
@@ -112,20 +111,30 @@ class AsyncBatchEmbeddings:
         ```
 
     Attributes:
-        client: An already‑configured ``openai.AsyncOpenAI`` client.
-        model_name: The model identifier, e.g. ``"text-embedding-3-small"``.
-        max_concurrency: Maximum number of concurrent requests to the OpenAI API.
+    client: An already‑configured ``openai.AsyncOpenAI`` client.
+    model_name: The model identifier, e.g. ``"text-embedding-3-small"``.
     """
 
     client: AsyncOpenAI
     model_name: str
-    max_concurrency: int = 8  # Default concurrency limit
-    _semaphore: asyncio.Semaphore = field(init=False, repr=False)
+    cache: AsyncBatchingMapProxy[str, NDArray[np.float32]] = field(
+        default_factory=lambda: AsyncBatchingMapProxy(batch_size=128, max_concurrency=8)
+    )
 
-    def __post_init__(self):
-        # Initialize the semaphore after the object is created
-        # Use object.__setattr__ because the dataclass is frozen
-        object.__setattr__(self, "_semaphore", asyncio.Semaphore(self.max_concurrency))
+    @classmethod
+    def of(
+        cls,
+        client: AsyncOpenAI,
+        model_name: str,
+        batch_size: int = 128,
+        max_concurrency: int = 8,
+    ) -> "AsyncBatchEmbeddings":
+        """Create an AsyncBatchEmbeddings instance configured with a batching proxy."""
+        return cls(
+            client=client,
+            model_name=model_name,
+            cache=AsyncBatchingMapProxy(batch_size=batch_size, max_concurrency=max_concurrency),
+        )
 
     @observe(_LOGGER)
     @backoff_async(exception=RateLimitError, scale=15, max_retries=8)
@@ -146,27 +155,10 @@ class AsyncBatchEmbeddings:
         Raises:
             openai.RateLimitError: Propagated if retries are exhausted.
         """
-        # Acquire semaphore before making the API call
-        async with self._semaphore:
-            responses = await self.client.embeddings.create(input=inputs, model=self.model_name)
-            return [np.array(d.embedding, dtype=np.float32) for d in responses.data]
+        responses = await self.client.embeddings.create(input=inputs, model=self.model_name)
+        return [np.array(d.embedding, dtype=np.float32) for d in responses.data]
 
     @observe(_LOGGER)
-    async def create(self, inputs: List[str], batch_size: int) -> List[NDArray[np.float32]]:
-        """Asynchronous public API: generate embeddings for a list of inputs.
-
-        Uses ``openaivec.util.map_async`` to efficiently handle batching and de-duplication.
-
-        Args:
-            inputs (List[str]): A list of input strings. Duplicates are handled efficiently.
-            batch_size (int): Maximum number of unique inputs per API call.
-
-        Returns:
-            A list of ``np.ndarray`` objects (dtype ``float32``) where each entry
-            is the embedding of the corresponding string in *inputs*.
-
-        Raises:
-            openai.RateLimitError: Propagated if retries are exhausted during API calls.
-        """
-
-        return await map_async(inputs, self._embed_chunk, batch_size)
+    async def create(self, inputs: List[str]) -> List[NDArray[np.float32]]:
+        """Asynchronous public API: generate embeddings for a list of inputs using proxy batching."""
+        return await self.cache.map(inputs, self._embed_chunk)

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -239,13 +239,14 @@ class OpenAIVecSeriesAccessor:
             pandas.Series: Series whose values are ``np.ndarray`` objects
                 (dtype ``float32``).
         """
-        client: BatchEmbeddings = BatchEmbeddings(
+        client: BatchEmbeddings = BatchEmbeddings.of(
             client=CONTAINER.resolve(OpenAI),
             model_name=CONTAINER.resolve(EmbeddingsModelName).value,
+            batch_size=batch_size,
         )
 
         return pd.Series(
-            client.create(self._obj.tolist(), batch_size=batch_size),
+            client.create(self._obj.tolist()),
             index=self._obj.index,
             name=self._obj.name,
         )
@@ -584,14 +585,15 @@ class AsyncOpenAIVecSeriesAccessor:
         Note:
             This is an asynchronous method and must be awaited.
         """
-        client: AsyncBatchEmbeddings = AsyncBatchEmbeddings(
+        client: AsyncBatchEmbeddings = AsyncBatchEmbeddings.of(
             client=CONTAINER.resolve(AsyncOpenAI),
             model_name=CONTAINER.resolve(EmbeddingsModelName).value,
+            batch_size=batch_size,
             max_concurrency=max_concurrency,
         )
 
         # Await the async operation
-        results = await client.create(self._obj.tolist(), batch_size=batch_size)
+        results = await client.create(self._obj.tolist())
 
         return pd.Series(
             results,

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -169,20 +169,16 @@ class OpenAIVecSeriesAccessor:
         Returns:
             pandas.Series: Series whose values are instances of ``response_format``.
         """
-        client: BatchResponses = BatchResponses(
+        client: BatchResponses = BatchResponses.of(
             client=CONTAINER.resolve(OpenAI),
             model_name=CONTAINER.resolve(ResponsesModelName).value,
             system_message=instructions,
             response_format=response_format,
             temperature=temperature,
             top_p=top_p,
+            batch_size=batch_size,
         )
-
-        return pd.Series(
-            client.parse(self._obj.tolist(), batch_size=batch_size),
-            index=self._obj.index,
-            name=self._obj.name,
-        )
+        return pd.Series(client.parse(self._obj.tolist()), index=self._obj.index, name=self._obj.name)
 
     def task(self, task: PreparedTask, batch_size: int = 128) -> pd.Series:
         """Execute a prepared task on every Series element.
@@ -215,14 +211,12 @@ class OpenAIVecSeriesAccessor:
                 response format, aligned with the original Series index.
         """
         client = BatchResponses.of_task(
-            client=CONTAINER.resolve(OpenAI), model_name=CONTAINER.resolve(ResponsesModelName).value, task=task
+            client=CONTAINER.resolve(OpenAI),
+            model_name=CONTAINER.resolve(ResponsesModelName).value,
+            task=task,
+            batch_size=batch_size,
         )
-
-        return pd.Series(
-            client.parse(self._obj.tolist(), batch_size=batch_size),
-            index=self._obj.index,
-            name=self._obj.name,
-        )
+        return pd.Series(client.parse(self._obj.tolist()), index=self._obj.index, name=self._obj.name)
 
     def embeddings(self, batch_size: int = 128) -> pd.Series:
         """Compute OpenAI embeddings for every Series element.
@@ -548,24 +542,20 @@ class AsyncOpenAIVecSeriesAccessor:
         Note:
             This is an asynchronous method and must be awaited.
         """
-        client: AsyncBatchResponses = AsyncBatchResponses(
+        client: AsyncBatchResponses = AsyncBatchResponses.of(
             client=CONTAINER.resolve(AsyncOpenAI),
             model_name=CONTAINER.resolve(ResponsesModelName).value,
             system_message=instructions,
             response_format=response_format,
             temperature=temperature,
             top_p=top_p,
+            batch_size=batch_size,
             max_concurrency=max_concurrency,
         )
-
         # Await the async operation
-        results = await client.parse(self._obj.tolist(), batch_size=batch_size)
+        results = await client.parse(self._obj.tolist())
 
-        return pd.Series(
-            results,
-            index=self._obj.index,
-            name=self._obj.name,
-        )
+        return pd.Series(results, index=self._obj.index, name=self._obj.name)
 
     async def embeddings(self, batch_size: int = 128, max_concurrency: int = 8) -> pd.Series:
         """Compute OpenAI embeddings for every Series element (asynchronously).
@@ -653,13 +643,9 @@ class AsyncOpenAIVecSeriesAccessor:
         )
 
         # Await the async operation
-        results = await client.parse(self._obj.tolist(), batch_size=batch_size)
+        results = await client.parse(self._obj.tolist())
 
-        return pd.Series(
-            results,
-            index=self._obj.index,
-            name=self._obj.name,
-        )
+        return pd.Series(results, index=self._obj.index, name=self._obj.name)
 
 
 @pd.api.extensions.register_dataframe_accessor("aio")

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -113,7 +113,7 @@ class BatchResponses(Generic[ResponseFormat]):
             model_name="gpt‑4o‑mini",
             system_message="You are a helpful assistant."
         )
-        answers = vector_llm.parse(questions, batch_size=32)
+    answers = vector_llm.parse(questions)
         ```
 
     Attributes:
@@ -282,7 +282,7 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         questions = ["What is the capital of France?", "Explain quantum physics simply."]
         # Asynchronous call
         async def main():
-            answers = await vector_llm.parse(questions, batch_size=32)
+            answers = await vector_llm.parse(questions)
             print(answers)
 
         # Run the async function
@@ -414,20 +414,15 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         return sorted_responses
 
     @observe(_LOGGER)
-    async def parse(self, inputs: List[str], batch_size: int) -> List[ResponseFormat | None]:
+    async def parse(self, inputs: List[str]) -> List[ResponseFormat | None]:
         """Asynchronous public API: batched predict.
 
         Args:
             inputs (List[str]): All prompts that require a response. Duplicate
                 entries are de-duplicated under the hood to save tokens.
-            batch_size (int): Maximum number of *unique* prompts per LLM call.
 
         Returns:
             A list containing the assistant responses in the same order as
                 *inputs*.
         """
-
-        return await self.cache.map(
-            inputs=inputs,
-            f=self._predict_chunk,
-        )
+        return await self.cache.map(inputs, self._predict_chunk)

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -113,7 +113,7 @@ class BatchResponses(Generic[ResponseFormat]):
             model_name="gpt‑4o‑mini",
             system_message="You are a helpful assistant."
         )
-    answers = vector_llm.parse(questions)
+        answers = vector_llm.parse(questions)
         ```
 
     Attributes:
@@ -247,7 +247,6 @@ class BatchResponses(Generic[ResponseFormat]):
         Args:
             inputs (List[str]): All prompts that require a response.  Duplicate
                 entries are de‑duplicated under the hood to save tokens.
-            batch_size (int): Maximum number of *unique* prompts per LLM call.
 
         Returns:
             A list containing the assistant responses in the same order as
@@ -268,24 +267,26 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         ```python
         import asyncio
         from openai import AsyncOpenAI
-        from openaivec.aio.responses import AsyncBatchResponses
+        from openaivec import AsyncBatchResponses
 
-        # Assuming openai_async_client is an initialized AsyncOpenAI client
-        openai_async_client = AsyncOpenAI() # Replace with your actual client initialization
+        openai_async_client = AsyncOpenAI()  # initialize your client
 
-        vector_llm = AsyncBatchResponses(
+        vector_llm = AsyncBatchResponses.of(
             client=openai_async_client,
             model_name="gpt-4.1-mini",
             system_message="You are a helpful assistant.",
-            max_concurrency=5  # Limit concurrent requests
+            batch_size=64,
+            max_concurrency=5,
         )
-        questions = ["What is the capital of France?", "Explain quantum physics simply."]
-        # Asynchronous call
+        questions = [
+            "What is the capital of France?",
+            "Explain quantum physics simply.",
+        ]
+
         async def main():
             answers = await vector_llm.parse(questions)
             print(answers)
 
-        # Run the async function
         asyncio.run(main())
         ```
 
@@ -297,7 +298,6 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         top_p: Nucleus-sampling parameter.
         response_format: Expected Pydantic BaseModel subclass or str type for each assistant message
             (defaults to `str`).
-        max_concurrency: Maximum number of concurrent requests to the OpenAI API.
     """
 
     client: AsyncOpenAI

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -222,7 +222,7 @@ class BatchResponses(Generic[ResponseFormat]):
         return cast(ParsedResponse[Response[ResponseFormat]], completion)
 
     @observe(_LOGGER)
-    def _predict_chunk(self, user_messages: List[str]) -> List[ResponseFormat]:
+    def _predict_chunk(self, user_messages: List[str]) -> List[ResponseFormat | None]:
         """Helper executed for every unique minibatch.
 
         This method:
@@ -241,7 +241,7 @@ class BatchResponses(Generic[ResponseFormat]):
         return sorted_responses
 
     @observe(_LOGGER)
-    def parse(self, inputs: List[str]) -> List[ResponseFormat]:
+    def parse(self, inputs: List[str]) -> List[ResponseFormat | None]:
         """Public API: batched predict.
 
         Args:
@@ -395,7 +395,7 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         return cast(ParsedResponse[Response[ResponseFormat]], completion)
 
     @observe(_LOGGER)
-    async def _predict_chunk(self, user_messages: List[str]) -> List[ResponseFormat]:
+    async def _predict_chunk(self, user_messages: List[str]) -> List[ResponseFormat | None]:
         """Helper executed asynchronously for every unique minibatch.
 
         This method:
@@ -414,7 +414,7 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         return sorted_responses
 
     @observe(_LOGGER)
-    async def parse(self, inputs: List[str], batch_size: int) -> List[ResponseFormat]:
+    async def parse(self, inputs: List[str], batch_size: int) -> List[ResponseFormat | None]:
         """Asynchronous public API: batched predict.
 
         Args:

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -337,7 +337,7 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
 
     @classmethod
     def of_task(
-        cls, client: AsyncOpenAI, model_name: str, task: PreparedTask, bach_size: int = 128, max_concurrency: int = 8
+        cls, client: AsyncOpenAI, model_name: str, task: PreparedTask, batch_size: int = 128, max_concurrency: int = 8
     ) -> "AsyncBatchResponses":
         """Create an AsyncBatchResponses instance from a PreparedTask."""
         return cls(
@@ -347,7 +347,7 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
             temperature=task.temperature,
             top_p=task.top_p,
             response_format=task.response_format,
-            cache=AsyncBatchingMapProxy(batch_size=bach_size, max_concurrency=max_concurrency),
+            cache=AsyncBatchingMapProxy(batch_size=batch_size, max_concurrency=max_concurrency),
         )
 
     def __post_init__(self):

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,8 +1,8 @@
-import unittest
 import asyncio
-import numpy as np
 import os
+import unittest
 
+import numpy as np
 from openai import AsyncOpenAI
 
 from openaivec.embeddings import AsyncBatchEmbeddings
@@ -17,14 +17,14 @@ class TestAsyncBatchEmbeddings(unittest.TestCase):
 
     def test_create_basic(self):
         """Test basic embedding creation with a small batch size."""
-        client = AsyncBatchEmbeddings(
+        client = AsyncBatchEmbeddings.of(
             client=self.openai_client,
             model_name=self.model_name,
+            batch_size=2,
         )
         inputs = ["apple", "banana", "orange", "pineapple"]
-        batch_size = 2
 
-        response = asyncio.run(client.create(inputs, batch_size=batch_size))
+        response = asyncio.run(client.create(inputs))
 
         self.assertEqual(len(response), len(inputs))
         for embedding in response:
@@ -35,25 +35,26 @@ class TestAsyncBatchEmbeddings(unittest.TestCase):
 
     def test_create_empty_input(self):
         """Test embedding creation with an empty input list."""
-        client = AsyncBatchEmbeddings(
+        client = AsyncBatchEmbeddings.of(
             client=self.openai_client,
             model_name=self.model_name,
+            batch_size=1,
         )
         inputs = []
-        response = asyncio.run(client.create(inputs, batch_size=1))
+        response = asyncio.run(client.create(inputs))
 
         self.assertEqual(len(response), 0)
 
     def test_create_with_duplicates(self):
         """Test embedding creation with duplicate inputs. Should return correct embeddings in order."""
-        client = AsyncBatchEmbeddings(
+        client = AsyncBatchEmbeddings.of(
             client=self.openai_client,
             model_name=self.model_name,
+            batch_size=2,
         )
         inputs = ["apple", "banana", "apple", "orange", "banana"]
-        batch_size = 2
 
-        response = asyncio.run(client.create(inputs, batch_size=batch_size))
+        response = asyncio.run(client.create(inputs))
 
         self.assertEqual(len(response), len(inputs))
         for embedding in response:
@@ -69,14 +70,14 @@ class TestAsyncBatchEmbeddings(unittest.TestCase):
 
     def test_create_batch_size_larger_than_unique(self):
         """Test when batch_size is larger than the number of unique inputs."""
-        client = AsyncBatchEmbeddings(
+        client = AsyncBatchEmbeddings.of(
             client=self.openai_client,
             model_name=self.model_name,
+            batch_size=5,
         )
         inputs = ["apple", "banana", "orange", "apple"]
-        batch_size = 5
 
-        response = asyncio.run(client.create(inputs, batch_size=batch_size))
+        response = asyncio.run(client.create(inputs))
 
         self.assertEqual(len(response), len(inputs))
         unique_inputs_first_occurrence_indices = {text: inputs.index(text) for text in set(inputs)}
@@ -88,14 +89,14 @@ class TestAsyncBatchEmbeddings(unittest.TestCase):
 
     def test_create_batch_size_one(self):
         """Test embedding creation with batch_size = 1."""
-        client = AsyncBatchEmbeddings(
+        client = AsyncBatchEmbeddings.of(
             client=self.openai_client,
             model_name=self.model_name,
+            batch_size=1,
         )
         inputs = ["apple", "banana", "orange"]
-        batch_size = 1
 
-        response = asyncio.run(client.create(inputs, batch_size=batch_size))
+        response = asyncio.run(client.create(inputs))
 
         self.assertEqual(len(response), len(inputs))
         for embedding in response:
@@ -105,16 +106,16 @@ class TestAsyncBatchEmbeddings(unittest.TestCase):
 
     def test_initialization_default_concurrency(self):
         """Test initialization uses default max_concurrency."""
-        client = AsyncBatchEmbeddings(
+        client = AsyncBatchEmbeddings.of(
             client=self.openai_client,
             model_name=self.model_name,
         )
-        self.assertEqual(client.max_concurrency, 8)
+        self.assertEqual(client.cache.max_concurrency, 8)
 
     def test_initialization_custom_concurrency(self):
         """Test initialization with custom max_concurrency."""
         custom_concurrency = 4
-        client = AsyncBatchEmbeddings(
+        client = AsyncBatchEmbeddings.of(
             client=self.openai_client, model_name=self.model_name, max_concurrency=custom_concurrency
         )
-        self.assertEqual(client.max_concurrency, custom_concurrency)
+        self.assertEqual(client.cache.max_concurrency, custom_concurrency)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -70,12 +70,13 @@ class TestAsyncBatchResponses(TestCase):
         system_message = """
         just repeat the user message
         """.strip()
-        client = AsyncBatchResponses(
+        client = AsyncBatchResponses.of(
             client=self.openai_client,
             model_name=self.model_name,
             system_message=system_message,
+            batch_size=1,
         )
-        response: List[str] = asyncio.run(client.parse(["apple", "orange", "banana", "pineapple"], batch_size=1))
+        response: List[str] = asyncio.run(client.parse(["apple", "orange", "banana", "pineapple"]))
         self.assertListEqual(response, ["apple", "orange", "banana", "pineapple"])
 
     def test_parse_structured(self):
@@ -99,10 +100,14 @@ class TestAsyncBatchResponses(TestCase):
             color: str
             taste: str
 
-        client = AsyncBatchResponses(
-            client=self.openai_client, model_name=self.model_name, system_message=system_message, response_format=Fruit
+        client = AsyncBatchResponses.of(
+            client=self.openai_client,
+            model_name=self.model_name,
+            system_message=system_message,
+            response_format=Fruit,
+            batch_size=1,
         )
-        response: List[Fruit] = asyncio.run(client.parse(input_fruits, batch_size=1))
+        response: List[Fruit] = asyncio.run(client.parse(input_fruits))
         self.assertEqual(len(response), len(input_fruits))
         for i, item in enumerate(response):
             self.assertIsInstance(item, Fruit)
@@ -122,10 +127,14 @@ class TestAsyncBatchResponses(TestCase):
             color: str
             taste: str
 
-        client = AsyncBatchResponses(
-            client=self.openai_client, model_name=self.model_name, system_message=system_message, response_format=Fruit
+        client = AsyncBatchResponses.of(
+            client=self.openai_client,
+            model_name=self.model_name,
+            system_message=system_message,
+            response_format=Fruit,
+            batch_size=1,
         )
-        response: List[Fruit] = asyncio.run(client.parse([], batch_size=1))
+        response: List[Fruit] = asyncio.run(client.parse([]))
         self.assertListEqual(response, [])
 
     def test_parse_structured_batch_size(self):
@@ -149,10 +158,14 @@ class TestAsyncBatchResponses(TestCase):
             color: str
             taste: str
 
-        client = AsyncBatchResponses(
-            client=self.openai_client, model_name=self.model_name, system_message=system_message, response_format=Fruit
+        client_bs2 = AsyncBatchResponses.of(
+            client=self.openai_client,
+            model_name=self.model_name,
+            system_message=system_message,
+            response_format=Fruit,
+            batch_size=2,
         )
-        response_bs2: List[Fruit] = asyncio.run(client.parse(input_fruits, batch_size=2))
+        response_bs2: List[Fruit] = asyncio.run(client_bs2.parse(input_fruits))
         self.assertEqual(len(response_bs2), len(input_fruits))
         for i, item in enumerate(response_bs2):
             self.assertIsInstance(item, Fruit)
@@ -162,7 +175,14 @@ class TestAsyncBatchResponses(TestCase):
             self.assertIsInstance(item.taste, str)
             self.assertTrue(len(item.taste) > 0)
 
-        response_bs4: List[Fruit] = asyncio.run(client.parse(input_fruits, batch_size=4))
+        client_bs4 = AsyncBatchResponses.of(
+            client=self.openai_client,
+            model_name=self.model_name,
+            system_message=system_message,
+            response_format=Fruit,
+            batch_size=4,
+        )
+        response_bs4: List[Fruit] = asyncio.run(client_bs4.parse(input_fruits))
         self.assertEqual(len(response_bs4), len(input_fruits))
         for i, item in enumerate(response_bs4):
             self.assertIsInstance(item, Fruit)


### PR DESCRIPTION
This pull request refactors the vectorized embeddings and responses APIs to use new batching proxy classes for improved batching, de-duplication, and caching. It introduces new factory constructors (`of`) for easier instantiation with batch parameters, simplifies the public API by removing redundant arguments, and updates the pandas extension and documentation for consistency. The changes also improve type annotations and docstrings for clarity.

**API and Interface Refactoring**

* Switched to using `BatchingMapProxy` and `AsyncBatchingMapProxy` for batching, de-duplication, and caching in `BatchEmbeddings`, `AsyncBatchEmbeddings`, and `BatchResponses`, replacing previous custom batching logic. Factory constructors (`of`) are introduced for cleaner instantiation with batch parameters. Public `create` and `parse` methods no longer require `batch_size` as an argument; batching is configured at construction. [[1]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0R9-R12) [[2]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L23-R83) [[3]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L115-R189) [[4]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dR9-R13) [[5]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL115-R125)

* Updated pandas extension methods to use the new `.of` constructors and removed the need to pass `batch_size` to `parse` and `create` calls. This affects both synchronous and asynchronous methods for responses and embeddings. [[1]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L172-R181) [[2]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L218-R219) [[3]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L248-R249) [[4]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L551-R559) [[5]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L597-R596) [[6]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L656-R650)

**Documentation and Usability**

* Updated docstrings and usage examples throughout the codebase to reflect the new batching and construction patterns, improving clarity and consistency. [[1]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L23-R83) [[2]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L88-R109) [[3]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL23-R24) [[4]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL33-R39) [[5]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL115-R125)

* Revised the `README.md` to show usage of the `.of` factory method and the new API, removing the need to pass `batch_size` to `parse`.

**Code Clean-up**

* Removed unused imports (`asyncio`) and deprecated utility functions (`map`, `map_async`) from affected modules, as batching is now handled by the new proxy classes. [[1]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L1) [[2]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL1) [[3]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0R9-R12) [[4]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dR9-R13)

Overall, these changes modernize and simplify the API for vectorized OpenAI calls, making batching and caching more robust and easier to use.