### PR TITLE
Enhance/spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,13 @@ Example Output (structure might vary slightly):
 
 When using openaivec with Spark, proper configuration of `batch_size` and `max_concurrency` is crucial for optimal performance:
 
+**Automatic Caching** (New):
+
+- **Duplicate Detection**: All response UDFs (`responses_udf`, `task_udf`) automatically cache duplicate inputs within each partition
+- **Cost Reduction**: Significantly reduces API calls and costs on datasets with repeated content
+- **Transparent**: Works automatically without code changes - your existing UDFs become more efficient
+- **Partition-Level**: Each partition maintains its own cache, optimal for distributed processing patterns
+
 **`batch_size`** (default: 128):
 
 - Controls how many rows are processed together in each API request within a partition


### PR DESCRIPTION
This pull request introduces automatic, partition-local caching for all response-generating Spark UDFs in the `openaivec` library, significantly reducing redundant API calls and costs when processing datasets with repeated content. The caching is fully transparent to users and does not require code changes. Comprehensive documentation and tests have been added to demonstrate and verify cache sharing across different data structures and execution modes.

Key changes include:

**Caching and Performance Improvements:**

- All response UDFs (`responses_udf`, `task_udf`) now use an `AsyncBatchingMapProxy` cache per partition, automatically deduplicating requests and reducing API usage for repeated inputs. This applies to both string and structured outputs. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL227-R237) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR289-R308) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR317-R335) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR353-R355) [[5]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR404-R422) [[6]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR431-R449)
- The cache is created at the start of each UDF evaluation and cleared at the end, ensuring memory is managed correctly and cache scope is limited to each partition. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR289-R308) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR317-R335) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR404-R422) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR431-R449)

**Documentation Updates:**

- The README and Spark module docstrings now highlight automatic caching as a key feature, explaining its benefits and usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R398-R404) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR10-R13) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL227-R237) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR276-R277) [[5]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR353-R355) [[6]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL345-R374) [[7]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR384-R387)

**Testing Enhancements:**

- Extensive new tests in `tests/test_pandas_ext.py` verify that shared caches correctly deduplicate requests across multiple Series and DataFrame objects, for both synchronous and asynchronous code paths, and for both responses and embeddings.

**Internal Refactoring:**

- Updated internal UDF implementations to use `responses_with_cache` instead of the previous `responses` method, and to accept a cache parameter. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL227-R237) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR289-R308) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR317-R335) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR404-R422) [[5]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR431-R449)
- Added necessary imports for `AsyncBatchingMapProxy` and related types.

These changes make the Spark integration in `openaivec` more efficient and cost-effective, especially for large-scale or repetitive datasets.