### PR TITLE
improve: embeddings_udf with cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ When using openaivec with Spark, proper configuration of `batch_size` and `max_c
 
 **Automatic Caching** (New):
 
-- **Duplicate Detection**: All response UDFs (`responses_udf`, `task_udf`) automatically cache duplicate inputs within each partition
+- **Duplicate Detection**: All AI-powered UDFs (`responses_udf`, `task_udf`, `embeddings_udf`) automatically cache duplicate inputs within each partition
 - **Cost Reduction**: Significantly reduces API calls and costs on datasets with repeated content
 - **Transparent**: Works automatically without code changes - your existing UDFs become more efficient
 - **Partition-Level**: Each partition maintains its own cache, optimal for distributed processing patterns


### PR DESCRIPTION
This pull request enhances the Spark integration of the `openaivec` package by extending automatic caching of duplicate inputs to all AI-powered UDFs, including the `embeddings_udf`. This reduces redundant API calls and costs when processing datasets with repeated content. Documentation and code comments have been updated to reflect these improvements, and the embedding UDF implementation now leverages a partition-local cache for optimal efficiency.

**Caching and performance improvements:**
- Extended automatic partition-level caching of duplicate inputs to include `embeddings_udf`, in addition to `responses_udf` and `task_udf`, reducing redundant API calls and costs for all AI-powered UDFs. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL10-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L400-R400) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL490-R501)
- Updated the implementation of `embeddings_udf` to use `embeddings_with_cache` with an `AsyncBatchingMapProxy` cache per partition, ensuring duplicate inputs are only processed once per partition and cache is cleared after use. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL462-R467) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR511-R521)

**Documentation and code clarity:**
- Updated docstrings and comments throughout `src/openaivec/spark.py` to clarify that all AI-powered UDFs now benefit from automatic caching, and described the benefits and usage considerations. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL462-R467) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL490-R501)
- Added missing import for `numpy` to support embedding array handling.