### PR TITLE
Enhance/backoff

### DIFF
--- a/src/openaivec/embeddings.py
+++ b/src/openaivec/embeddings.py
@@ -47,7 +47,7 @@ class BatchEmbeddings:
         return cls(client=client, model_name=model_name, cache=BatchingMapProxy(batch_size=batch_size))
 
     @observe(_LOGGER)
-    @backoff(exceptions=[RateLimitError, InternalServerError], scale=15, max_retries=8)
+    @backoff(exceptions=[RateLimitError, InternalServerError], scale=1, max_retries=12)
     def _embed_chunk(self, inputs: List[str]) -> List[NDArray[np.float32]]:
         """Embed one minibatch of strings.
 
@@ -155,7 +155,7 @@ class AsyncBatchEmbeddings:
         )
 
     @observe(_LOGGER)
-    @backoff_async(exceptions=[RateLimitError, InternalServerError], scale=15, max_retries=8)
+    @backoff_async(exceptions=[RateLimitError, InternalServerError], scale=1, max_retries=12)
     async def _embed_chunk(self, inputs: List[str]) -> List[NDArray[np.float32]]:
         """Embed one minibatch of strings asynchronously.
 

--- a/src/openaivec/embeddings.py
+++ b/src/openaivec/embeddings.py
@@ -4,7 +4,7 @@ from typing import List
 
 import numpy as np
 from numpy.typing import NDArray
-from openai import AsyncOpenAI, OpenAI, RateLimitError
+from openai import AsyncOpenAI, InternalServerError, OpenAI, RateLimitError
 
 from .log import observe
 from .proxy import AsyncBatchingMapProxy, BatchingMapProxy
@@ -47,7 +47,7 @@ class BatchEmbeddings:
         return cls(client=client, model_name=model_name, cache=BatchingMapProxy(batch_size=batch_size))
 
     @observe(_LOGGER)
-    @backoff(exception=RateLimitError, scale=15, max_retries=8)
+    @backoff(exceptions=[RateLimitError, InternalServerError], scale=15, max_retries=8)
     def _embed_chunk(self, inputs: List[str]) -> List[NDArray[np.float32]]:
         """Embed one minibatch of strings.
 
@@ -155,7 +155,7 @@ class AsyncBatchEmbeddings:
         )
 
     @observe(_LOGGER)
-    @backoff_async(exception=RateLimitError, scale=15, max_retries=8)
+    @backoff_async(exceptions=[RateLimitError, InternalServerError], scale=15, max_retries=8)
     async def _embed_chunk(self, inputs: List[str]) -> List[NDArray[np.float32]]:
         """Embed one minibatch of strings asynchronously.
 

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from logging import Logger, getLogger
 from typing import Generic, List, Type, cast
 
-from openai import AsyncOpenAI, OpenAI, RateLimitError
+from openai import AsyncOpenAI, InternalServerError, OpenAI, RateLimitError
 from openai.types.responses import ParsedResponse
 from pydantic import BaseModel
 
@@ -206,7 +206,7 @@ class BatchResponses(Generic[ResponseFormat]):
         )
 
     @observe(_LOGGER)
-    @backoff(exception=RateLimitError, scale=15, max_retries=8)
+    @backoff(exceptions=[RateLimitError, InternalServerError], scale=15, max_retries=8)
     def _request_llm(self, user_messages: List[Message[str]]) -> ParsedResponse[Response[ResponseFormat]]:
         """Make a single call to the OpenAI JSON‑mode endpoint.
 
@@ -400,7 +400,7 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         )
 
     @observe(_LOGGER)
-    @backoff_async(exception=RateLimitError, scale=15, max_retries=8)
+    @backoff_async(exceptions=[RateLimitError, InternalServerError], scale=15, max_retries=8)
     async def _request_llm(self, user_messages: List[Message[str]]) -> ParsedResponse[Response[ResponseFormat]]:
         """Make a single async call to the OpenAI JSON‑mode endpoint.
 

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -206,7 +206,7 @@ class BatchResponses(Generic[ResponseFormat]):
         )
 
     @observe(_LOGGER)
-    @backoff(exceptions=[RateLimitError, InternalServerError], scale=15, max_retries=8)
+    @backoff(exceptions=[RateLimitError, InternalServerError], scale=1, max_retries=12)
     def _request_llm(self, user_messages: List[Message[str]]) -> ParsedResponse[Response[ResponseFormat]]:
         """Make a single call to the OpenAI JSON‑mode endpoint.
 
@@ -400,7 +400,7 @@ class AsyncBatchResponses(Generic[ResponseFormat]):
         )
 
     @observe(_LOGGER)
-    @backoff_async(exceptions=[RateLimitError, InternalServerError], scale=15, max_retries=8)
+    @backoff_async(exceptions=[RateLimitError, InternalServerError], scale=1, max_retries=12)
     async def _request_llm(self, user_messages: List[Message[str]]) -> ParsedResponse[Response[ResponseFormat]]:
         """Make a single async call to the OpenAI JSON‑mode endpoint.
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,10 @@
+import asyncio
+import time
 from unittest import TestCase
 
 import tiktoken
 
-from openaivec.util import TextChunker
+from openaivec.util import TextChunker, backoff, backoff_async
 
 
 class TestTextChunker(TestCase):
@@ -39,3 +41,222 @@ Until version 1.18, Kubernetes followed an N-2 support policy, meaning that the 
 
         for chunk in chunks:
             self.assertLessEqual(len(enc.encode(chunk)), 256)
+
+
+class TestBackoff(TestCase):
+    def test_backoff_no_exception(self):
+        """Test that function executes normally when no exception is raised."""
+        call_count = 0
+
+        @backoff(exceptions=[ValueError], scale=0.1, max_retries=3)
+        def success_func():
+            nonlocal call_count
+            call_count += 1
+            return "success"
+
+        result = success_func()
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 1)
+
+    def test_backoff_retries_on_exception(self):
+        """Test that function retries on specified exception."""
+        call_count = 0
+
+        @backoff(exceptions=[ValueError], scale=0.01, max_retries=3)
+        def fail_twice():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("Test error")
+            return "success"
+
+        result = fail_twice()
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 3)
+
+    def test_backoff_multiple_exceptions(self):
+        """Test that function retries on multiple exception types."""
+        call_count = 0
+
+        @backoff(exceptions=[ValueError, TypeError], scale=0.01, max_retries=5)
+        def fail_with_different_errors():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("First error")
+            elif call_count == 2:
+                raise TypeError("Second error")
+            return "success"
+
+        result = fail_with_different_errors()
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 3)
+
+    def test_backoff_max_retries_exceeded(self):
+        """Test that function raises exception when max retries exceeded."""
+        call_count = 0
+
+        @backoff(exceptions=[ValueError], scale=0.01, max_retries=2)
+        def always_fail():
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("Always fails")
+
+        with self.assertRaises(ValueError) as cm:
+            always_fail()
+        self.assertEqual(str(cm.exception), "Always fails")
+        self.assertEqual(call_count, 2)  # Initial call + 1 retry
+
+    def test_backoff_unhandled_exception_not_retried(self):
+        """Test that unhandled exceptions are not retried."""
+        call_count = 0
+
+        @backoff(exceptions=[ValueError], scale=0.01, max_retries=3)
+        def raise_unhandled():
+            nonlocal call_count
+            call_count += 1
+            raise TypeError("Unhandled exception")
+
+        with self.assertRaises(TypeError) as cm:
+            raise_unhandled()
+        self.assertEqual(str(cm.exception), "Unhandled exception")
+        self.assertEqual(call_count, 1)  # No retries for unhandled exception
+
+    def test_backoff_exponential_delay(self):
+        """Test that delay increases exponentially."""
+        call_times = []
+
+        @backoff(exceptions=[ValueError], scale=0.01, max_retries=3)
+        def track_timing():
+            call_times.append(time.time())
+            if len(call_times) < 3:
+                raise ValueError("Retry")
+            return "success"
+
+        result = track_timing()
+        self.assertEqual(result, "success")
+        self.assertEqual(len(call_times), 3)
+
+        # Check that delays are present (but keep them small for test speed)
+        for i in range(1, len(call_times)):
+            delay = call_times[i] - call_times[i - 1]
+            self.assertGreater(delay, 0)  # Some delay exists
+
+
+class TestBackoffAsync(TestCase):
+    def test_backoff_async_no_exception(self):
+        """Test that async function executes normally when no exception is raised."""
+        call_count = 0
+
+        @backoff_async(exceptions=[ValueError], scale=0.1, max_retries=3)
+        async def success_func():
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)
+            return "success"
+
+        result = asyncio.run(success_func())
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 1)
+
+    def test_backoff_async_retries_on_exception(self):
+        """Test that async function retries on specified exception."""
+        call_count = 0
+
+        @backoff_async(exceptions=[ValueError], scale=0.01, max_retries=3)
+        async def fail_twice():
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)
+            if call_count < 3:
+                raise ValueError("Test error")
+            return "success"
+
+        result = asyncio.run(fail_twice())
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 3)
+
+    def test_backoff_async_multiple_exceptions(self):
+        """Test that async function retries on multiple exception types."""
+        call_count = 0
+
+        @backoff_async(exceptions=[ValueError, TypeError], scale=0.01, max_retries=5)
+        async def fail_with_different_errors():
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)
+            if call_count == 1:
+                raise ValueError("First error")
+            elif call_count == 2:
+                raise TypeError("Second error")
+            return "success"
+
+        result = asyncio.run(fail_with_different_errors())
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 3)
+
+    def test_backoff_async_max_retries_exceeded(self):
+        """Test that async function raises exception when max retries exceeded."""
+        call_count = 0
+
+        @backoff_async(exceptions=[ValueError], scale=0.01, max_retries=2)
+        async def always_fail():
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)
+            raise ValueError("Always fails")
+
+        with self.assertRaises(ValueError) as cm:
+            asyncio.run(always_fail())
+        self.assertEqual(str(cm.exception), "Always fails")
+        self.assertEqual(call_count, 2)  # Initial call + 1 retry
+
+    def test_backoff_async_unhandled_exception_not_retried(self):
+        """Test that unhandled exceptions are not retried in async."""
+        call_count = 0
+
+        @backoff_async(exceptions=[ValueError], scale=0.01, max_retries=3)
+        async def raise_unhandled():
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)
+            raise TypeError("Unhandled exception")
+
+        with self.assertRaises(TypeError) as cm:
+            asyncio.run(raise_unhandled())
+        self.assertEqual(str(cm.exception), "Unhandled exception")
+        self.assertEqual(call_count, 1)  # No retries for unhandled exception
+
+    def test_backoff_async_with_openai_exceptions(self):
+        """Test backoff with OpenAI exception types."""
+        # Import OpenAI exceptions for testing
+        try:
+            from openai import RateLimitError, InternalServerError
+            from unittest.mock import Mock
+            
+            call_count = 0
+
+            # Create a mock response object
+            mock_response = Mock()
+            mock_response.request = Mock()
+            mock_response.status_code = 429  # For RateLimitError
+            
+            @backoff_async(exceptions=[RateLimitError, InternalServerError], scale=0.01, max_retries=3)
+            async def simulate_api_errors():
+                nonlocal call_count
+                call_count += 1
+                await asyncio.sleep(0.01)
+                if call_count == 1:
+                    mock_response.status_code = 429
+                    raise RateLimitError("Rate limit hit", response=mock_response, body=None)
+                elif call_count == 2:
+                    mock_response.status_code = 500
+                    raise InternalServerError("Server error", response=mock_response, body=None)
+                return "success"
+
+            result = asyncio.run(simulate_api_errors())
+            self.assertEqual(result, "success")
+            self.assertEqual(call_count, 3)
+        except ImportError:
+            # Skip test if OpenAI is not installed
+            self.skipTest("OpenAI not installed")


### PR DESCRIPTION
This pull request refactors and extends the backoff retry logic in the codebase to support retrying on multiple exception types, not just one, and adds comprehensive tests for this functionality. The changes improve robustness when handling OpenAI API errors and ensure both synchronous and asynchronous retry behaviors are well-tested.

**Backoff logic enhancements:**

* Refactored the `backoff` and `backoff_async` decorators in `src/openaivec/util.py` to accept a list of exception types (via a new `exceptions` parameter), allowing retries on multiple error types instead of just one. The implementation and documentation were updated accordingly. [[1]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L37-R58) [[2]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L68-R72) [[3]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L86-R97) [[4]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L101-R110) [[5]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L118-R124)
* Updated all usages of `backoff` and `backoff_async` in `src/openaivec/embeddings.py` and `src/openaivec/responses.py` to pass both `RateLimitError` and `InternalServerError` as retryable exceptions, and adjusted the retry parameters for more robust error handling. [[1]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L7-R7) [[2]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L50-R50) [[3]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L158-R158) [[4]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL5-R5) [[5]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL209-R209) [[6]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL403-R403)

**Testing improvements:**

* Added an extensive new test class `TestBackoff` and `TestBackoffAsync` in `tests/test_util.py` to verify the new backoff behavior, including correct retrying on multiple exception types, handling of max retries, unhandled exceptions, exponential delays, and integration with OpenAI-specific exceptions. [[1]](diffhunk://#diff-0dcbadaa6c70afb6fea041dec04bb89c3cc7fe201fb7c3185a669efa49769f28R1-R7) [[2]](diffhunk://#diff-0dcbadaa6c70afb6fea041dec04bb89c3cc7fe201fb7c3185a669efa49769f28R44-R291)

**Type and import fixes:**

* Updated type annotations and imports in `src/openaivec/util.py` to support the new backoff signatures and ensure type correctness.

These changes collectively make the retry logic more flexible and reliable, especially when dealing with transient API errors, and ensure correctness through thorough testing.