### PR TITLE
Feature/autoschemaextraction

### DIFF
--- a/src/openaivec/_schema.py
+++ b/src/openaivec/_schema.py
@@ -71,8 +71,7 @@ class InferredSchema(BaseModel):
         )
     )
 
-    # Convenience -----------------------------------------------------------------
-    def build_model(self) -> Type[BaseModel]:  # pragma: no cover - thin logic, exercised indirectly in tests
+    def build_model(self) -> Type[BaseModel]:
         """Materialize a dynamic ``BaseModel`` matching this inferred schema.
 
         Rules:

--- a/src/openaivec/_schema.py
+++ b/src/openaivec/_schema.py
@@ -1,0 +1,374 @@
+import json
+from dataclasses import dataclass
+from json import JSONDecodeError
+from typing import Any, Dict, List, Literal, Optional, Type
+
+from openai import OpenAI
+from openai.types.responses import ParsedResponse
+from pydantic import BaseModel, Field
+
+from openaivec._serialize import deserialize_base_model
+
+# Internal module: explicitly not part of public API
+__all__: list[str] = []
+
+
+class SuggestedField(BaseModel):
+    name: str = Field(
+        description=(
+            "Lower snake_case identifier (regex: ^[a-z][a-z0-9_]*$). Must be unique across all fields and "
+            "express the semantic meaning succinctly (no adjectives like 'best', 'great')."
+        )
+    )
+    type: Literal["string", "integer", "float", "boolean"] = Field(
+        description=(
+            "Primitive type. Use 'integer' only if all observed numeric values are whole numbers. "
+            "Use 'float' if any value can contain a decimal or represents a ratio/score. Use 'boolean' only for "
+            "explicit binary states (yes/no, true/false, present/absent) consistently encoded. Use 'string' otherwise. "
+            "Never output arrays, objects, or composite encodings; flatten to the most specific scalar value."
+        )
+    )
+    description: str = Field(
+        description=(
+            "Concise, objective definition plus extraction rule (what qualifies / what to ignore). Avoid subjective, "
+            "speculative, or promotional language. If ambiguity exists with another field, clarify the distinction."
+        )
+    )
+    enum_values: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Optional finite categorical label set (classification) for a string field. Provide ONLY when a closed, "
+            "stable vocabulary (2–24 lowercase tokens) is clearly evidenced or strongly implied by examples. "
+            "Do NOT invent labels. Omit if open-ended or ambiguous. Order must be stable and semantically natural."
+        ),
+    )
+
+
+class SuggestedSchema(BaseModel):
+    purpose: str = Field(
+        description=(
+            "Normalized, unambiguous restatement of the user objective with redundant, vague, or "
+            "conflicting phrasing removed."
+        )
+    )
+    example_data_description: str = Field(
+        description=(
+            "Objective characterization of the provided examples: content domain, structure, recurring "
+            "patterns, and notable constraints."
+        )
+    )
+    suggested_schema: List[SuggestedField] = Field(
+        description=(
+            "Ordered list of proposed fields derived strictly from observable, repeatable signals in the "
+            "examples and aligned with the purpose."
+        )
+    )
+    json_schema_string: str = Field(
+        description=(
+            "JSON Schema (Draft 2020-12) as a string, following Pydantic v2 export conventions. Must "
+            "exactly reflect the fields in 'suggested_schema' (names, types) without adding, removing, or "
+            "renaming any field."
+        )
+    )
+    suggested_prompt: str = Field(
+        description=(
+            "Canonical, reusable extraction prompt for structuring future inputs with this schema. "
+            "Must be fully derivable from 'purpose', 'example_data_description', and 'suggested_schema' "
+            "(no new unstated facts or speculation). It MUST: (1) instruct the model to output only the "
+            "listed fields with the exact names and primitive types; (2) forbid adding, removing, or "
+            "renaming fields; (3) avoid subjective or marketing language; (4) be self-contained (no TODOs, "
+            "no external references, no unresolved placeholders). Intended for direct reuse as the prompt "
+            "in an extraction phase to ensure deterministic alignment with 'json_schema_string'."
+        )
+    )
+
+
+class ExampleData(BaseModel):
+    examples: List[str] = Field(
+        description=(
+            "Representative sample texts (strings). Provide only data the schema should generalize over; "
+            "exclude outliers not in scope."
+        )
+    )
+    purpose: str = Field(
+        description=(
+            "Plain language statement describing the downstream use of the extracted structured data (e.g. "
+            "analytics, filtering, enrichment)."
+        )
+    )
+
+
+def _validate_consistency(parsed: SuggestedSchema, schema_dict: Dict[str, Any]) -> None:
+    """Validate that the machine schema matches the intermediate field proposal.
+
+    We enforce a strict 1:1 correspondence between ``suggested_schema`` entries and
+    the properties defined in ``json_schema_string`` to catch drift introduced by the
+    model during the final serialization step.
+    """
+
+    # Normalize schema first (tolerate common LLM deviations)
+    _normalize_schema(schema_dict)
+
+    props = schema_dict.get("properties")
+    if not isinstance(props, dict):  # Defensive; model must output object schema
+        raise ValueError("json_schema_string must define an object with 'properties'.")
+
+    suggested_names = [f.name for f in parsed.suggested_schema]
+    schema_names = list(props.keys())
+
+    if suggested_names != schema_names:
+        raise ValueError(
+            "Inconsistent field ordering or names between suggested_schema and json_schema_string: "
+            f"suggested={suggested_names} schema={schema_names}"
+        )
+
+    type_map = {"float": "number", "integer": "integer", "string": "string", "boolean": "boolean"}
+    for f in parsed.suggested_schema:
+        spec = props.get(f.name)
+        if not isinstance(spec, dict):
+            raise ValueError(f"Property '{f.name}' missing in json_schema_string.")
+        declared_type = spec.get("type")
+        expected_type = type_map[f.type]
+        # Tolerate 'float' as an alias for JSON Schema 'number'
+        if declared_type == "float" and expected_type == "number":
+            # Normalize in-place so downstream consumers see canonical form
+            spec["type"] = "number"
+            declared_type = "number"
+        if declared_type != expected_type:
+            raise ValueError(
+                f"Type mismatch for field '{f.name}': suggested '{f.type}' -> expected schema type "
+                f"'{expected_type}', got '{declared_type}'."
+            )
+        # Enum consistency (only allowed for string fields)
+        if f.enum_values is not None:
+            if f.type != "string":
+                raise ValueError(
+                    f"Field '{f.name}' supplies enum_values but type is '{f.type}' (only 'string' may define enum)."
+                )
+            schema_enum = spec.get("enum")
+            if not isinstance(schema_enum, list):
+                # Tolerant repair: inject missing enum array to align with suggested_schema
+                spec["enum"] = f.enum_values
+                schema_enum = f.enum_values
+            if schema_enum != f.enum_values:
+                raise ValueError(f"Field '{f.name}' enum mismatch: suggested {f.enum_values} schema {schema_enum}.")
+        else:
+            # If schema has enum but model omitted enum_values, allow (model may have inferred a closed set).
+            pass
+
+
+INSTRUCTIONS = """
+You are a schema inference engine.
+
+Task:
+1. Normalize the user's purpose (remove ambiguity, redundancy, and contradictions).
+2. Objectively summarize the example data's observable structure and patterns.
+3. Propose a minimal, sufficient set of flat scalar fields (no nesting, arrays, or objects) that can be
+    reliably extracted.
+4. Avoid introducing a field if it would plausibly be missing for a significant portion of examples (~>20%).
+5. Where a field represents a small closed set of categorical labels (classification), infer an enum of
+    stable, distinct lowercase values (2–24). Do NOT invent categories not evidenced or strongly implied; omit
+    enum otherwise.
+6. If the purpose indicates a predictive task (mentions words like 'predict', 'probability', 'likelihood'), treat
+        the goal as feature engineering: propose explanatory (independent) features only. DO NOT create fields that
+        restate or trivially encode the prediction target itself (e.g., do not add 'attrition_probability', 'will_buy',
+        'purchase_likelihood'). Instead surface stable, textual signals that could help a downstream model.
+7. Produce a JSON Schema Draft 2020-12 (Pydantic v2 style) whose properties exactly correspond to the proposed fields.
+
+Rules:
+- Field names: lower snake_case; regex ^[a-z][a-z0-9_]*$; unique; no subjective adjectives.
+- Allowed types: string | integer | float | boolean.
+  * Use integer only if all observed numeric values are whole numbers.
+  * Use float if any numeric value may contain decimals or represents a score/ratio.
+  * Use boolean only when examples clearly encode a binary state (true/false or yes/no consistently).
+  * Otherwise use string.
+- Do not output arrays, objects, nested structures, or composite types.
+- Do not hallucinate fields not clearly inferable from examples + purpose.
+- Do not merge multiple independent concepts into one field.
+- The 'json_schema_string' must: (a) define an object type, (b) include a 'properties' object, (c) include
+    every field in suggested_schema in the same order, (d) not introduce additional properties.
+- Keep descriptions concise and objective; avoid marketing, emotion, or speculation.
+- For enum_values: only supply for string fields when the set is finite, closed, and small. Omit if open-ended.
+- Field definitions MUST NOT include implicit lists concatenated in strings (e.g. comma-separated lists)
+    to emulate arrays.
+- If uncertainty exists between two potential fields, prefer the single clearer, consistently extractable one.
+- For predictive/feature engineering purposes: exclude direct outcome labels or probabilities; focus on stable
+    precursors, signals, or attributes derivable from the text (e.g. 'expressed_sentiment', 'delivery_issue_type').
+
+Output contract:
+Return data strictly conforming to the Provided Pydantic model (SuggestedSchema). Do not add fields.
+""".strip()
+
+
+@dataclass(frozen=True)
+class SchemaSuggester:
+    """Infer and materialize a dynamic Pydantic model from representative examples.
+
+    The class orchestrates a structured call to the OpenAI Responses API, requesting
+    an intermediate reasoning object (``SuggestedSchema``) plus a machine‑readable
+    JSON Schema. It then validates strict consistency between the intermediate
+    field proposal and the JSON Schema prior to constructing a concrete ``BaseModel``
+    subclass via dynamic deserialization.
+
+    Attributes:
+        client (OpenAI): Instantiated OpenAI client used for the Responses API.
+        model_name (str): Model (or Azure deployment) identifier passed to the
+            Responses API.
+    """
+
+    client: OpenAI
+    model_name: str
+
+    def suggest_schema(self, data: ExampleData, *args, max_retries: int = 3, **kwargs) -> SuggestedSchema:
+        """Infer and return a validated ``SuggestedSchema`` object.
+
+        Args:
+            data (ExampleData): Representative example texts plus extraction purpose.
+            *args: Additional positional arguments forwarded to ``client.responses.parse``.
+            max_retries (int): Maximum attempts to obtain a structurally consistent schema when
+                the model output fails validation. Must be >= 1.
+            **kwargs: Additional keyword arguments forwarded to ``client.responses.parse``.
+
+        Returns:
+            SuggestedSchema: Parsed structured schema proposal (purpose, data summary, field specs,
+            JSON Schema string, canonical extraction prompt) guaranteed to be internally consistent.
+
+        Raises:
+            ValueError: If after ``max_retries`` attempts the JSON schema and intermediate field list still
+                differ in order, names, types, or enum specifications.
+        """
+        if max_retries < 1:
+            raise ValueError("max_retries must be >= 1")
+
+        last_err: Exception | None = None
+        for attempt in range(1, max_retries + 1):
+            response: ParsedResponse[SuggestedSchema] = self.client.responses.parse(
+                model=self.model_name,
+                instructions=INSTRUCTIONS,
+                input=data.model_dump_json(),
+                text_format=SuggestedSchema,
+                *args,
+                **kwargs,
+            )
+
+            parsed = response.output_parsed
+            json_schema_dict = _load_lenient_json(parsed.json_schema_string)
+            # Apply normalization early so downstream validation and tests receive cleaned schema
+            _normalize_schema(json_schema_dict)
+            # Persist normalized form back onto the parsed object so callers see the cleaned schema
+            try:
+                # Secondary normalization: convert any lingering 'float' primitive types to JSON Schema 'number'
+                props = json_schema_dict.get("properties")
+                if isinstance(props, dict):
+                    for _n, _spec in props.items():
+                        if isinstance(_spec, dict) and _spec.get("type") == "float":
+                            _spec["type"] = "number"
+                parsed.json_schema_string = json.dumps(json_schema_dict, ensure_ascii=False)
+            except Exception:
+                # Non-fatal; continue with validation using normalized dict
+                pass
+            try:
+                _validate_consistency(parsed, json_schema_dict)
+                return parsed
+            except ValueError as e:  # Structural mismatch; retry if attempts remain
+                last_err = e
+                if attempt == max_retries:
+                    raise
+                continue
+
+        # Defensive (loop should return or raise)
+        if last_err:
+            raise last_err
+        raise RuntimeError("Schema inference failed unexpectedly without error context.")
+
+
+def materialize_model(suggestion: SuggestedSchema) -> Type[BaseModel]:
+    """Construct a dynamic ``BaseModel`` subclass from a validated ``SuggestedSchema``.
+
+    This is a convenience helper to turn the already consistency-checked JSON Schema string
+    into a concrete Pydantic model class for downstream parsing / validation tasks.
+
+    Args:
+        suggestion (SuggestedSchema): A schema suggestion returned by ``SchemaSuggester.suggest_schema``.
+
+    Returns:
+        Type[BaseModel]: Dynamically created model type matching the suggestion.
+    """
+
+    return deserialize_base_model(_load_lenient_json(suggestion.json_schema_string))
+
+
+def _load_lenient_json(text: str) -> Dict[str, Any]:
+    """Attempt to parse JSON, tolerating trailing unmatched closing braces produced by LLMs.
+
+    Strategy: try normal json.loads; on Extra data error, use JSONDecoder.raw_decode to grab the first
+    complete JSON value and ensure the remainder contains only closing braces / whitespace. If so, accept
+    the first value; otherwise re-raise.
+    """
+
+    try:
+        return json.loads(text)
+    except JSONDecodeError:
+        # Heuristic: find the last position where braces are balanced and truncate there.
+        depth = 0
+        last_good_index = None
+        for i, ch in enumerate(text):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    last_good_index = i + 1
+        if last_good_index is not None:
+            candidate = text[:last_good_index]
+            try:
+                obj = json.loads(candidate)
+                if not isinstance(obj, dict):
+                    raise ValueError("Top-level JSON schema must be an object")
+                return obj
+            except JSONDecodeError:
+                pass
+        # Fallback to original exception behavior
+        raise
+
+
+def _normalize_schema(schema_dict: Dict[str, Any]) -> None:
+    """In-place normalization of common LLM schema quirks for consistency checking.
+
+    - Convert 'enum_values' -> 'enum' where appropriate
+    - Collapse optional patterns encoded as anyOf/oneOf [T, null] into a single 'type'
+    - Remove unknown keys that can cause noise (currently only pass-through)
+    """
+
+    props = schema_dict.get("properties")
+    if not isinstance(props, dict):
+        return
+    for name, spec in props.items():
+        if not isinstance(spec, dict):
+            continue
+        # enum_values -> enum
+        if "enum_values" in spec and "enum" not in spec:
+            ev = spec.get("enum_values")
+            if isinstance(ev, list) and all(isinstance(x, str) for x in ev):
+                spec["enum"] = ev
+            spec.pop("enum_values", None)
+        # anyOf optional pattern (allow rewriting even if 'type' present but ambiguous)
+        if "anyOf" in spec:
+            any_of = spec.get("anyOf")
+            if isinstance(any_of, list):
+                non_null = [x for x in any_of if isinstance(x, dict) and x.get("type") not in {None, "null"}]
+                if len(non_null) == 1 and isinstance(non_null[0], dict):
+                    candidate_type = non_null[0].get("type")
+                    if candidate_type in {"string", "integer", "number", "boolean"}:
+                        spec["type"] = candidate_type
+                        if "enum" in non_null[0] and "enum" not in spec:
+                            spec["enum"] = non_null[0]["enum"]
+                        spec.pop("anyOf", None)
+        # Final safeguard: if still no type but an anyOf with primitive + null exists, force collapse
+        if "type" not in spec and isinstance(spec.get("anyOf"), list):
+            primitives = [
+                x.get("type") for x in spec["anyOf"] if isinstance(x, dict) and x.get("type") not in {None, "null"}
+            ]
+            if len(primitives) == 1 and primitives[0] in {"string", "integer", "number", "boolean"}:
+                spec["type"] = primitives[0]
+                spec.pop("anyOf", None)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,19 +1,121 @@
+import os
 import unittest
-from typing import List
 from unittest.mock import patch
 
 from openai import OpenAI
 from pydantic import BaseModel
 
-from openaivec._schema import (  # type: ignore
-    InferredSchema,
-    SchemaInferenceInput,
-    SchemaInferer,
-    materialize_model_simple,
-)
+from openaivec._schema import InferredSchema, SchemaInferenceInput, SchemaInferer  # type: ignore
+
+# Use a non-reasoning mainstream model for all schema tests
+SCHEMA_TEST_MODEL = "gpt-4.1-mini"
 
 
 class TestSchemaInferer(unittest.TestCase):
+    # Central catalog of schema inference scenarios
+    DATASETS: dict[str, SchemaInferenceInput] = {
+        "operational_status": SchemaInferenceInput(
+            examples=[
+                "Order #9912 refunded due to damaged item.",
+                "Order #9913 resolved: replacement shipped.",
+                "Order #9914 pending investigation about missing parts.",
+            ],
+            purpose="Infer minimal operational status and high-level issue classification for analytics.",
+        ),
+        "rating_sentiment": SchemaInferenceInput(
+            examples=[
+                "Rating: 4.5/5 - Fast delivery, packaging slightly dented.",
+                "Rating: 2/5 - Slow shipping and unresponsive support.",
+                "Rating: 5/5 - Excellent build quality and service.",
+            ],
+            purpose="Infer numeric rating and sentiment category as flat scalar features.",
+        ),
+        "issue_type_login": SchemaInferenceInput(
+            examples=[
+                "User: can't login after password reset though reset email succeeded.",
+                "User: login works but dashboard widgets fail to load intermittently.",
+                "User: account locked after multiple 2FA code failures.",
+            ],
+            purpose="Extract concise issue type classification and any consistently extractable signal.",
+        ),
+        "basic_support_signals": SchemaInferenceInput(
+            examples=[
+                "Order #1234: customer requested refund due to damaged packaging.",
+                "Order #1235: customer happy, praised fast shipping.",
+                "Order #1236: delayed delivery complaint, wants status update.",
+            ],
+            purpose="Extract concise operational signals helpful for simple analytics (issue type, sentiment).",
+        ),
+        "sentiment_enum_detection": SchemaInferenceInput(
+            examples=[
+                "Absolutely excellent product quality and fantastic support (clearly positive).",
+                "Terrible experience and horrible customer support (clearly negative).",
+                "Average / neutral overall, nothing especially good or bad (clearly neutral).",
+                "Mixed feelings: mostly good build but disappointing battery (mixed).",
+            ],
+            purpose=(
+                "Infer a categorical sentiment_label (small closed enum: e.g. positive, negative, neutral, mixed) and any other reliably extractable flat scalar signals. Provide enum values if evident."
+            ),
+        ),
+        "battery_quality": SchemaInferenceInput(
+            examples=[
+                "Battery life is great and fast charging is helpful.",
+                "Battery drains quickly and overheats sometimes.",
+            ],
+            purpose="Infer sentiment and one or two consistent quality signals as flat scalar fields.",
+        ),
+        "shipping_quality_simple": SchemaInferenceInput(
+            examples=[
+                "Positive experience: fast shipping and solid build quality.",
+                "Negative: slow delivery and fragile packaging.",
+            ],
+            purpose="Infer a sentiment_label enum (positive/negative) plus any one additional quality signal if stable.",
+        ),
+        "status_resolution_retry": SchemaInferenceInput(
+            examples=[
+                "User reported login failure after password reset.",
+                "User confirmed issue was resolved after cache clear.",
+            ],
+            purpose="Extract key status signal (issue vs resolution) as minimal fields.",
+        ),
+        "battery_ui_reliability": SchemaInferenceInput(
+            examples=[
+                "Great battery life and responsive UI.",
+                "Battery drains fast and UI is sluggish.",
+            ],
+            purpose="Infer sentiment and one reliability signal as flat scalar fields.",
+        ),
+        "attrition_features": SchemaInferenceInput(
+            examples=[
+                "Employee notes: workload high, considering options, manager support low.",
+                "Employee notes: satisfied with team collaboration and growth opportunities.",
+                "Employee notes: neutral performance period, seeking clearer career path.",
+            ],
+            purpose="Predict employee attrition probability; propose explanatory text-derived features only (no direct target).",
+        ),
+        "purchase_features": SchemaInferenceInput(
+            examples=[
+                "User viewed premium plan pricing and asked about discount.",
+                "User compared basic vs pro, mentioned limited budget.",
+                "User requested integration docs and asked about SLA terms.",
+            ],
+            purpose="Predict purchase probability; propose only explanatory scalar features (no purchase outcome field).",
+        ),
+    }
+
+    # Cache of inferred schemas (populated once in setUpClass to avoid duplicate API calls)
+    INFERRED: dict[str, InferredSchema] = {}
+
+    @classmethod
+    def setUpClass(cls):  # noqa: D401 - standard unittest hook
+        """Infer schemas for all datasets once (live API) to reuse across tests."""
+        if "OPENAI_API_KEY" not in os.environ:
+            raise RuntimeError("OPENAI_API_KEY not set (tests require real API per project policy)")
+        client = OpenAI()
+        inferer = SchemaInferer(client=client, model_name=SCHEMA_TEST_MODEL)
+        for name, ds in cls.DATASETS.items():
+            cls.INFERRED[name] = inferer.infer_schema(ds, max_retries=2)
+
     @staticmethod
     def _assert_basic_invariants(t: "unittest.TestCase", s: InferredSchema) -> None:  # type: ignore[name-defined]
         t.assertIsInstance(s.purpose, str)
@@ -32,97 +134,42 @@ class TestSchemaInferer(unittest.TestCase):
                 t.assertGreaterEqual(len(f.enum_values), 2)
                 t.assertLessEqual(len(f.enum_values), 24)
 
-    def test_basic(self):
+    def _infer(self, examples: list[str], purpose: str, retries: int = 2) -> InferredSchema:
+        if "OPENAI_API_KEY" not in os.environ:
+            self.fail("OPENAI_API_KEY not set (tests require real API per project policy)")
         client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        data = SchemaInferenceInput(
-            examples=[
-                "Order #1234: customer requested refund due to damaged packaging.",
-                "Order #1235: customer happy, praised fast shipping.",
-                "Order #1236: delayed delivery complaint, wants status update.",
-            ],
-            purpose="Extract concise operational signals helpful for simple analytics (issue type, sentiment).",
-        )
-        suggestion = inferer.infer_schema(data, max_retries=2)
-        self._assert_basic_invariants(self, suggestion)
+        inferer = SchemaInferer(client=client, model_name=SCHEMA_TEST_MODEL)
+        data = SchemaInferenceInput(examples=examples, purpose=purpose)
+        return inferer.infer_schema(data, max_retries=retries)
 
-    def test_enum_detection(self):
-        client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        data = SchemaInferenceInput(
-            examples=[
-                "Absolutely excellent product quality and fantastic support (clearly positive).",
-                "Terrible experience and horrible customer support (clearly negative).",
-                "Average / neutral overall, nothing especially good or bad (clearly neutral).",
-                "Mixed feelings: mostly good build but disappointing battery (mixed).",
-            ],
-            purpose=(
-                "Infer a categorical sentiment_label (small closed enum: e.g. positive, negative, neutral, mixed) "
-                "and any other reliably extractable flat scalar signals. Provide enum values if evident."
-            ),
-        )
-        suggestion = inferer.infer_schema(data, max_retries=2)
-        self._assert_basic_invariants(self, suggestion)
-        has_enum = any(f.enum_values for f in suggestion.fields)
+    # --- A. Inference invariants across all datasets ---
+    def test_inference_invariants_all_datasets(self):
+        for name, inferred in self.INFERRED.items():
+            with self.subTest(dataset=name):
+                self._assert_basic_invariants(self, inferred)
+
+    # --- B. Enum / categorical detection ---
+    def test_enum_detection_sentiment_dataset(self):
+        inferred = self.INFERRED["sentiment_enum_detection"]
+        self._assert_basic_invariants(self, inferred)
+        has_enum = any(f.enum_values for f in inferred.fields)
         if not has_enum:
-            sentiment_like = [f for f in suggestion.fields if "sentiment" in f.name]
-            # Allow absence (models may choose more generic labels); ensure at least one string field exists
-            string_fields = [f for f in suggestion.fields if f.type == "string"]
-            self.assertTrue(
-                sentiment_like or string_fields,
-                "expected at least one string field when sentiment enum absent",
-            )
+            sentiment_like = [f for f in inferred.fields if "sentiment" in f.name]
+            string_fields = [f for f in inferred.fields if f.type == "string"]
+            self.assertTrue(sentiment_like or string_fields)
 
-    def test_materialize_model(self):
-        client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        data = SchemaInferenceInput(
-            examples=[
-                "Battery life is great and fast charging is helpful.",
-                "Battery drains quickly and overheats sometimes.",
-            ],
-            purpose="Infer sentiment and one or two consistent quality signals as flat scalar fields.",
-        )
-        suggestion = inferer.infer_schema(data, max_retries=2)
-        model_cls = materialize_model_simple(suggestion)
-        self.assertTrue(issubclass(model_cls, BaseModel))
-        schema = model_cls.model_json_schema()
-        self.assertTrue("properties" in schema and schema["properties"], "expected non-empty properties")
-
-    def test_materialize_model_simple(self):
-        from openaivec._schema import materialize_model_simple  # local import to avoid circular concerns
-
-        client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        data = SchemaInferenceInput(
-            examples=[
-                "Positive experience: fast shipping and solid build quality.",
-                "Negative: slow delivery and fragile packaging.",
-            ],
-            purpose=(
-                "Infer a sentiment_label enum (positive/negative) plus any one additional quality signal if stable."
-            ),
-        )
-        suggestion = inferer.infer_schema(data, max_retries=2)
-        simple_model = materialize_model_simple(suggestion)
-        self.assertTrue(issubclass(simple_model, BaseModel))
-        props = simple_model.model_json_schema().get("properties", {})
-        self.assertTrue(props)
-        # Ensure every suggested field became a property
-        self.assertEqual(set(props.keys()), {f.name for f in suggestion.fields})
+    # --- C. Model materialization (build_model) ---
+    def test_build_model_all_datasets(self):
+        for name, inferred in self.INFERRED.items():
+            with self.subTest(dataset=name):
+                model_cls = inferred.build_model()
+                self.assertTrue(issubclass(model_cls, BaseModel))
+                props = model_cls.model_json_schema().get("properties", {})
+                self.assertTrue(props)
+                self.assertEqual(set(props.keys()), {f.name for f in inferred.fields})
 
     def test_retry(self):
-        client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        data = SchemaInferenceInput(
-            examples=[
-                "User reported login failure after password reset.",
-                "User confirmed issue was resolved after cache clear.",
-            ],
-            purpose="Extract key status signal (issue vs resolution) as minimal fields.",
-        )
-
-        calls: List[int] = []
+        calls: list[int] = []
 
         def flaky_once(parsed):  # type: ignore
             calls.append(1)
@@ -131,126 +178,100 @@ class TestSchemaInferer(unittest.TestCase):
             return None
 
         with patch("openaivec._schema._basic_field_list_validation", side_effect=flaky_once):
-            suggestion = inferer.infer_schema(data, max_retries=3)
+            ds = self.DATASETS["status_resolution_retry"]
+            suggestion = self._infer(ds.examples, ds.purpose, retries=3)
         self._assert_basic_invariants(self, suggestion)
-        self.assertGreaterEqual(len(calls), 2, "should have retried after induced failure")
+        self.assertGreaterEqual(len(calls), 2)
 
-    def test_deserialize_base_model(self):
-        client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        data = SchemaInferenceInput(
-            examples=[
-                "Great battery life and responsive UI.",
-                "Battery drains fast and UI is sluggish.",
-            ],
-            purpose="Infer sentiment and one reliability signal as flat scalar fields.",
-        )
-        suggestion = inferer.infer_schema(data, max_retries=2)
-        model_cls = materialize_model_simple(suggestion)
-        self.assertTrue(issubclass(model_cls, BaseModel))
-        props = model_cls.model_json_schema().get("properties", {})
-        self.assertEqual(list(props.keys()), [f.name for f in suggestion.fields])
-
-    def test_feature_engineering_attrition(self):
-        client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        data = SchemaInferenceInput(
-            examples=[
-                "Employee notes: workload high, considering options, manager support low.",
-                "Employee notes: satisfied with team collaboration and growth opportunities.",
-                "Employee notes: neutral performance period, seeking clearer career path.",
-            ],
-            purpose=(
-                "Predict employee attrition probability; propose explanatory text-derived features only (no direct target)."
-            ),
-        )
-        suggestion = inferer.infer_schema(data, max_retries=2)
-        self._assert_basic_invariants(self, suggestion)
-        field_names = {f.name for f in suggestion.fields}
+    # --- D. Feature engineering constraints (no target leakage) ---
+    def test_feature_engineering_attrition_no_target(self):
+        inferred = self.INFERRED["attrition_features"]
+        field_names = {f.name for f in inferred.fields}
         forbidden = {"attrition_probability", "will_leave", "leave_label"}
-        self.assertFalse(field_names & forbidden, f"Forbidden target-like fields present: {field_names & forbidden}")
-        model_cls = materialize_model_simple(suggestion)
-        self.assertTrue(issubclass(model_cls, BaseModel))
+        self.assertFalse(field_names & forbidden)
+        inferred.build_model()
 
-    def test_feature_engineering_purchase(self):
-        client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        data = SchemaInferenceInput(
-            examples=[
-                "User viewed premium plan pricing and asked about discount.",
-                "User compared basic vs pro, mentioned limited budget.",
-                "User requested integration docs and asked about SLA terms.",
-            ],
-            purpose=(
-                "Predict purchase probability; propose only explanatory scalar features (no purchase outcome field)."
-            ),
-        )
-        suggestion = inferer.infer_schema(data, max_retries=2)
-        self._assert_basic_invariants(self, suggestion)
-        field_names = {f.name for f in suggestion.fields}
+    def test_feature_engineering_purchase_no_target(self):
+        inferred = self.INFERRED["purchase_features"]
+        field_names = {f.name for f in inferred.fields}
         forbidden = {"purchase_probability", "will_buy", "purchase_label"}
-        self.assertFalse(field_names & forbidden, f"Forbidden target-like fields present: {field_names & forbidden}")
-        model_cls = materialize_model_simple(suggestion)
-        self.assertTrue(issubclass(model_cls, BaseModel))
+        self.assertFalse(field_names & forbidden)
+        inferred.build_model()
 
-    def test_multiple_example_sets_deserialize(self):
-        """Integration: multiple real prompts must yield JSON schema parsable into a dynamic model."""
+    # --- E. Second-pass structuring (Responses.parse with dynamic model) ---
+    def test_structuring_operational_status(self):
+        inferred = self.INFERRED["operational_status"]
+        raw = self.DATASETS["operational_status"].examples[0]
+        structured = self._structure_one_example(inferred, raw)
+        self.assertIsInstance(structured, BaseModel)
+        for f in inferred.fields:
+            self.assertTrue(hasattr(structured, f.name))
+
+    def test_structuring_rating_sentiment(self):
+        inferred = self.INFERRED["rating_sentiment"]
+        raw = self.DATASETS["rating_sentiment"].examples[0]
+        structured = self._structure_one_example(inferred, raw)
+        self.assertIsInstance(structured, BaseModel)
+        names = {f.name for f in inferred.fields}
+        self.assertTrue(any(k in names for k in ("rating", "sentiment", "sentiment_label")))
+        for f in inferred.fields:
+            self.assertTrue(hasattr(structured, f.name))
+
+    def test_structuring_issue_type(self):
+        inferred = self.INFERRED["issue_type_login"]
+        raw = self.DATASETS["issue_type_login"].examples[0]
+        structured = self._structure_one_example(inferred, raw)
+        self.assertIsInstance(structured, BaseModel)
+        for f in inferred.fields:
+            self.assertTrue(hasattr(structured, f.name))
+
+    def _structure_one_example(
+        self, suggestion: InferredSchema, example_text: str, model_name: str = SCHEMA_TEST_MODEL
+    ):
+        """Perform a real second pass structuring call using the schema's inference_prompt.
+
+        Args:
+            suggestion (InferredSchema): Previously inferred schema via Responses.parse.
+            example_text (str): One raw example text (must be from the original examples set per contract).
+            model_name (str): Model/deployment name.
+        Returns:
+            BaseModel: Parsed structured instance produced by second pass.
+        """
         client = OpenAI()
-        inferer = SchemaInferer(client=client, model_name="gpt-5-mini")
-        datasets: List[SchemaInferenceInput] = [
-            SchemaInferenceInput(
-                examples=[
-                    "Order #9912 refunded due to damaged item.",
-                    "Order #9913 resolved: replacement shipped.",
-                    "Order #9914 pending investigation about missing parts.",
-                ],
-                purpose="Infer minimal operational status and high-level issue classification for analytics.",
-            ),
-            SchemaInferenceInput(
-                examples=[
-                    "Rating: 4.5/5 - Fast delivery, packaging slightly dented.",
-                    "Rating: 2/5 - Slow shipping and unresponsive support.",
-                    "Rating: 5/5 - Excellent build quality and service.",
-                ],
-                purpose="Infer numeric rating and sentiment category as flat scalar features.",
-            ),
-            SchemaInferenceInput(
-                examples=[
-                    "User: can't login after password reset though reset email succeeded.",
-                    "User: login works but dashboard widgets fail to load intermittently.",
-                    "User: account locked after multiple 2FA code failures.",
-                ],
-                purpose="Extract concise issue type classification and any consistently extractable signal.",
-            ),
-        ]
+        model_cls = suggestion.build_model()
+        parsed = client.responses.parse(
+            model=model_name,
+            instructions=suggestion.inference_prompt,
+            input=example_text,
+            text_format=model_cls,
+        )
+        return parsed.output_parsed
 
-        for data in datasets:
-            suggestion = inferer.infer_schema(data, max_retries=3)
-            self._assert_basic_invariants(self, suggestion)
-            model_cls = materialize_model_simple(suggestion)
-            self.assertTrue(issubclass(model_cls, BaseModel))
-            props = model_cls.model_json_schema().get("properties", {})
-            self.assertTrue(props, "expected non-empty properties")
-            for spec in props.values():
-                primitive_types = {"string", "integer", "number", "boolean"}
-                t = spec.get("type")
-                if t is None and "anyOf" in spec:
-                    any_of = spec["anyOf"]
-                    if isinstance(any_of, list) and 1 <= len(any_of) <= 2:
-                        prims = [
-                            x.get("type") for x in any_of if isinstance(x, dict) and x.get("type") in primitive_types
-                        ]
-                        nulls = [x for x in any_of if isinstance(x, dict) and x.get("type") == "null"]
-                        self.assertEqual(len(prims), 1, "unexpected anyOf structure")
-                        self.assertLessEqual(len(nulls), 1, "unexpected anyOf null structure")
-                    else:
-                        self.fail("unexpected anyOf structure for optional primitive")
-                else:
-                    self.assertIn(t, primitive_types)
-                self.assertNotIn("items", spec)
-                self.assertNotEqual(spec.get("type"), "object")
-                if "enum" in spec:
-                    self.assertTrue(isinstance(spec["enum"], list) and 2 <= len(spec["enum"]) <= 24)
+    def test_structuring_basic_support(self):
+        inferred = self.INFERRED["basic_support_signals"]
+        raw = self.DATASETS["basic_support_signals"].examples[0]
+        structured = self._structure_one_example(inferred, raw)
+        self.assertIsInstance(structured, BaseModel)
+        for f in inferred.fields:
+            self.assertTrue(hasattr(structured, f.name))
+
+    def test_structuring_attrition_features(self):
+        inferred = self.INFERRED["attrition_features"]
+        raw = self.DATASETS["attrition_features"].examples[0]
+        structured = self._structure_one_example(inferred, raw)
+        self.assertIsInstance(structured, BaseModel)
+        forbidden = {"attrition_probability", "will_leave", "leave_label"}
+        for name in forbidden:
+            self.assertFalse(hasattr(structured, name))
+
+    def test_structuring_purchase_features(self):
+        inferred = self.INFERRED["purchase_features"]
+        raw = self.DATASETS["purchase_features"].examples[0]
+        structured = self._structure_one_example(inferred, raw)
+        self.assertIsInstance(structured, BaseModel)
+        forbidden = {"purchase_probability", "will_buy", "purchase_label"}
+        for name in forbidden:
+            self.assertFalse(hasattr(structured, name))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,6 @@
+import unittest
 from typing import List
+from unittest.mock import patch
 
 from openai import OpenAI
 from pydantic import BaseModel
@@ -14,222 +16,224 @@ from openaivec._schema import (  # type: ignore
 from openaivec._serialize import deserialize_base_model
 
 
-def _assert_basic_invariants(s: SuggestedSchema) -> None:
-    assert isinstance(s.purpose, str) and s.purpose
-    assert isinstance(s.example_data_description, str) and s.example_data_description
-    assert isinstance(s.suggested_schema, list) and len(s.suggested_schema) > 0
-    names = [f.name for f in s.suggested_schema]
-    assert len(names) == len(set(names)), "field names must be unique"
-    for f in s.suggested_schema:
-        assert f.type in {"string", "integer", "float", "boolean"}
-        assert f.description and isinstance(f.description, str)
-        if f.enum_values is not None:
-            assert f.type == "string"
-            assert 2 <= len(f.enum_values) <= 24
-    schema_dict = _load_lenient_json(s.json_schema_string)
-    _validate_consistency(s, schema_dict)
+class TestSchemaSuggester(unittest.TestCase):
+    @staticmethod
+    def _assert_basic_invariants(t: "unittest.TestCase", s: SuggestedSchema) -> None:  # type: ignore[name-defined]
+        t.assertIsInstance(s.purpose, str)
+        t.assertTrue(s.purpose)
+        t.assertIsInstance(s.example_data_description, str)
+        t.assertTrue(s.example_data_description)
+        t.assertIsInstance(s.suggested_schema, list)
+        t.assertGreater(len(s.suggested_schema), 0)
+        names = [f.name for f in s.suggested_schema]
+        t.assertEqual(len(names), len(set(names)), "field names must be unique")
+        for f in s.suggested_schema:
+            t.assertIn(f.type, {"string", "integer", "float", "boolean"})
+            t.assertTrue(f.description and isinstance(f.description, str))
+            if f.enum_values is not None:
+                t.assertEqual(f.type, "string")
+                t.assertGreaterEqual(len(f.enum_values), 2)
+                t.assertLessEqual(len(f.enum_values), 24)
+        schema_dict = _load_lenient_json(s.json_schema_string)
+        _validate_consistency(s, schema_dict)
 
-
-def test_schema_suggester_basic():
-    client = OpenAI()
-    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
-    data = ExampleData(
-        examples=[
-            "Order #1234: customer requested refund due to damaged packaging.",
-            "Order #1235: customer happy, praised fast shipping.",
-            "Order #1236: delayed delivery complaint, wants status update.",
-        ],
-        purpose="Extract concise operational signals helpful for simple analytics (issue type, sentiment).",
-    )
-    suggestion = suggester.suggest_schema(data, max_retries=2)
-    _assert_basic_invariants(suggestion)
-
-
-def test_schema_suggester_enum_detection():
-    client = OpenAI()
-    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
-    data = ExampleData(
-        examples=[
-            "Absolutely excellent product quality and fantastic support (clearly positive).",
-            "Terrible experience and horrible customer support (clearly negative).",
-            "Average / neutral overall, nothing especially good or bad (clearly neutral).",
-            "Mixed feelings: mostly good build but disappointing battery (mixed).",
-        ],
-        purpose=(
-            "Infer a categorical sentiment_label (small closed enum: e.g. positive, negative, neutral, mixed) "
-            "and any other reliably extractable flat scalar signals. Provide enum values if evident."
-        ),
-    )
-    suggestion = suggester.suggest_schema(data, max_retries=2)
-    _assert_basic_invariants(suggestion)
-    has_enum = any(f.enum_values for f in suggestion.suggested_schema)
-    if not has_enum:
-        sentiment_like = [f for f in suggestion.suggested_schema if "sentiment" in f.name]
-        assert sentiment_like, "expected a sentiment field or an enum with sentiment labels"
-
-
-def test_schema_suggester_materialize_model():
-    client = OpenAI()
-    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
-    data = ExampleData(
-        examples=[
-            "Battery life is great and fast charging is helpful.",
-            "Battery drains quickly and overheats sometimes.",
-        ],
-        purpose="Infer sentiment and one or two consistent quality signals as flat scalar fields.",
-    )
-    suggestion = suggester.suggest_schema(data, max_retries=2)
-    model_cls = materialize_model(suggestion)
-    assert issubclass(model_cls, BaseModel)
-    schema = model_cls.model_json_schema()
-    assert "properties" in schema and schema["properties"], "expected non-empty properties"
-
-
-def test_schema_suggester_retry(monkeypatch):  # type: ignore
-    client = OpenAI()
-    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
-    data = ExampleData(
-        examples=[
-            "User reported login failure after password reset.",
-            "User confirmed issue was resolved after cache clear.",
-        ],
-        purpose="Extract key status signal (issue vs resolution) as minimal fields.",
-    )
-
-    calls: List[int] = []
-
-    def flaky_once(parsed, schema_dict):  # type: ignore
-        calls.append(1)
-        if len(calls) == 1:
-            raise ValueError("synthetic mismatch to trigger retry")
-        # Succeed silently on subsequent validations (bypass full validation to test retry path)
-        return None
-
-    monkeypatch.setattr("openaivec._schema._validate_consistency", flaky_once)  # type: ignore
-
-    suggestion = suggester.suggest_schema(data, max_retries=3)
-    _assert_basic_invariants(suggestion)
-    assert len(calls) >= 2, "should have retried after induced failure"
-
-
-def test_schema_deserialize_base_model():
-    client = OpenAI()
-    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
-    data = ExampleData(
-        examples=[
-            "Great battery life and responsive UI.",
-            "Battery drains fast and UI is sluggish.",
-        ],
-        purpose="Infer sentiment and one reliability signal as flat scalar fields.",
-    )
-    suggestion = suggester.suggest_schema(data, max_retries=2)
-    schema_dict = _load_lenient_json(suggestion.json_schema_string)
-    model_cls = deserialize_base_model(schema_dict)
-    assert issubclass(model_cls, BaseModel)
-    props = model_cls.model_json_schema().get("properties", {})
-    assert list(props.keys()) == [f.name for f in suggestion.suggested_schema]
-
-
-def test_schema_feature_engineering_attrition():
-    client = OpenAI()
-    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
-    data = ExampleData(
-        examples=[
-            "Employee notes: workload high, considering options, manager support low.",
-            "Employee notes: satisfied with team collaboration and growth opportunities.",
-            "Employee notes: neutral performance period, seeking clearer career path.",
-        ],
-        purpose=(
-            "Predict employee attrition probability; propose explanatory text-derived features only (no direct target)."
-        ),
-    )
-    suggestion = suggester.suggest_schema(data, max_retries=2)
-    _assert_basic_invariants(suggestion)
-    field_names = {f.name for f in suggestion.suggested_schema}
-    forbidden = {"attrition_probability", "will_leave", "leave_label"}
-    assert not (field_names & forbidden), f"Forbidden target-like fields present: {field_names & forbidden}"
-    # Ensure deserialization still works
-    schema_dict = _load_lenient_json(suggestion.json_schema_string)
-    model_cls = deserialize_base_model(schema_dict)
-    assert issubclass(model_cls, BaseModel)
-
-
-def test_schema_feature_engineering_purchase():
-    client = OpenAI()
-    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
-    data = ExampleData(
-        examples=[
-            "User viewed premium plan pricing and asked about discount.",
-            "User compared basic vs pro, mentioned limited budget.",
-            "User requested integration docs and asked about SLA terms.",
-        ],
-        purpose=("Predict purchase probability; propose only explanatory scalar features (no purchase outcome field)."),
-    )
-    suggestion = suggester.suggest_schema(data, max_retries=2)
-    _assert_basic_invariants(suggestion)
-    field_names = {f.name for f in suggestion.suggested_schema}
-    forbidden = {"purchase_probability", "will_buy", "purchase_label"}
-    assert not (field_names & forbidden), f"Forbidden target-like fields present: {field_names & forbidden}"
-    schema_dict = _load_lenient_json(suggestion.json_schema_string)
-    model_cls = deserialize_base_model(schema_dict)
-    assert issubclass(model_cls, BaseModel)
-
-
-def test_schema_multiple_example_sets_deserialize():
-    """Integration: multiple real prompts must yield JSON schema parsable into a dynamic model."""
-    client = OpenAI()
-    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
-
-    datasets: List[ExampleData] = [
-        ExampleData(
+    def test_basic(self):
+        client = OpenAI()
+        suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+        data = ExampleData(
             examples=[
-                "Order #9912 refunded due to damaged item.",
-                "Order #9913 resolved: replacement shipped.",
-                "Order #9914 pending investigation about missing parts.",
+                "Order #1234: customer requested refund due to damaged packaging.",
+                "Order #1235: customer happy, praised fast shipping.",
+                "Order #1236: delayed delivery complaint, wants status update.",
             ],
-            purpose="Infer minimal operational status and high-level issue classification for analytics.",
-        ),
-        ExampleData(
-            examples=[
-                "Rating: 4.5/5 - Fast delivery, packaging slightly dented.",
-                "Rating: 2/5 - Slow shipping and unresponsive support.",
-                "Rating: 5/5 - Excellent build quality and service.",
-            ],
-            purpose="Infer numeric rating and sentiment category as flat scalar features.",
-        ),
-        ExampleData(
-            examples=[
-                "User: can't login after password reset though reset email succeeded.",
-                "User: login works but dashboard widgets fail to load intermittently.",
-                "User: account locked after multiple 2FA code failures.",
-            ],
-            purpose="Extract concise issue type classification and any consistently extractable signal.",
-        ),
-    ]
+            purpose="Extract concise operational signals helpful for simple analytics (issue type, sentiment).",
+        )
+        suggestion = suggester.suggest_schema(data, max_retries=2)
+        self._assert_basic_invariants(self, suggestion)
 
-    for data in datasets:
-        suggestion = suggester.suggest_schema(data, max_retries=3)
-        _assert_basic_invariants(suggestion)
+    def test_enum_detection(self):
+        client = OpenAI()
+        suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+        data = ExampleData(
+            examples=[
+                "Absolutely excellent product quality and fantastic support (clearly positive).",
+                "Terrible experience and horrible customer support (clearly negative).",
+                "Average / neutral overall, nothing especially good or bad (clearly neutral).",
+                "Mixed feelings: mostly good build but disappointing battery (mixed).",
+            ],
+            purpose=(
+                "Infer a categorical sentiment_label (small closed enum: e.g. positive, negative, neutral, mixed) "
+                "and any other reliably extractable flat scalar signals. Provide enum values if evident."
+            ),
+        )
+        suggestion = suggester.suggest_schema(data, max_retries=2)
+        self._assert_basic_invariants(self, suggestion)
+        has_enum = any(f.enum_values for f in suggestion.suggested_schema)
+        if not has_enum:
+            sentiment_like = [f for f in suggestion.suggested_schema if "sentiment" in f.name]
+            self.assertTrue(sentiment_like, "expected a sentiment field or an enum with sentiment labels")
+
+    def test_materialize_model(self):
+        client = OpenAI()
+        suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+        data = ExampleData(
+            examples=[
+                "Battery life is great and fast charging is helpful.",
+                "Battery drains quickly and overheats sometimes.",
+            ],
+            purpose="Infer sentiment and one or two consistent quality signals as flat scalar fields.",
+        )
+        suggestion = suggester.suggest_schema(data, max_retries=2)
+        model_cls = materialize_model(suggestion)
+        self.assertTrue(issubclass(model_cls, BaseModel))
+        schema = model_cls.model_json_schema()
+        self.assertTrue("properties" in schema and schema["properties"], "expected non-empty properties")
+
+    def test_retry(self):
+        client = OpenAI()
+        suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+        data = ExampleData(
+            examples=[
+                "User reported login failure after password reset.",
+                "User confirmed issue was resolved after cache clear.",
+            ],
+            purpose="Extract key status signal (issue vs resolution) as minimal fields.",
+        )
+
+        calls: List[int] = []
+
+        def flaky_once(parsed, schema_dict):  # type: ignore
+            calls.append(1)
+            if len(calls) == 1:
+                raise ValueError("synthetic mismatch to trigger retry")
+            return None
+
+        with patch("openaivec._schema._validate_consistency", side_effect=flaky_once):
+            suggestion = suggester.suggest_schema(data, max_retries=3)
+        self._assert_basic_invariants(self, suggestion)
+        self.assertGreaterEqual(len(calls), 2, "should have retried after induced failure")
+
+    def test_deserialize_base_model(self):
+        client = OpenAI()
+        suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+        data = ExampleData(
+            examples=[
+                "Great battery life and responsive UI.",
+                "Battery drains fast and UI is sluggish.",
+            ],
+            purpose="Infer sentiment and one reliability signal as flat scalar fields.",
+        )
+        suggestion = suggester.suggest_schema(data, max_retries=2)
         schema_dict = _load_lenient_json(suggestion.json_schema_string)
         model_cls = deserialize_base_model(schema_dict)
-        assert issubclass(model_cls, BaseModel)
+        self.assertTrue(issubclass(model_cls, BaseModel))
         props = model_cls.model_json_schema().get("properties", {})
-        assert props, "expected non-empty properties"
-        for spec in props.values():
-            primitive_types = {"string", "integer", "number", "boolean"}
-            t = spec.get("type")
-            if t is None and "anyOf" in spec:
-                # Accept optional pattern anyOf [primitive, null]
-                any_of = spec["anyOf"]
-                if isinstance(any_of, list) and 1 <= len(any_of) <= 2:
-                    prims = [x.get("type") for x in any_of if isinstance(x, dict) and x.get("type") in primitive_types]
-                    nulls = [x for x in any_of if isinstance(x, dict) and x.get("type") == "null"]
-                    assert len(prims) == 1 and len(nulls) <= 1, "unexpected anyOf structure"
+        self.assertEqual(list(props.keys()), [f.name for f in suggestion.suggested_schema])
+
+    def test_feature_engineering_attrition(self):
+        client = OpenAI()
+        suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+        data = ExampleData(
+            examples=[
+                "Employee notes: workload high, considering options, manager support low.",
+                "Employee notes: satisfied with team collaboration and growth opportunities.",
+                "Employee notes: neutral performance period, seeking clearer career path.",
+            ],
+            purpose=(
+                "Predict employee attrition probability; propose explanatory text-derived features only (no direct target)."
+            ),
+        )
+        suggestion = suggester.suggest_schema(data, max_retries=2)
+        self._assert_basic_invariants(self, suggestion)
+        field_names = {f.name for f in suggestion.suggested_schema}
+        forbidden = {"attrition_probability", "will_leave", "leave_label"}
+        self.assertFalse(field_names & forbidden, f"Forbidden target-like fields present: {field_names & forbidden}")
+        schema_dict = _load_lenient_json(suggestion.json_schema_string)
+        model_cls = deserialize_base_model(schema_dict)
+        self.assertTrue(issubclass(model_cls, BaseModel))
+
+    def test_feature_engineering_purchase(self):
+        client = OpenAI()
+        suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+        data = ExampleData(
+            examples=[
+                "User viewed premium plan pricing and asked about discount.",
+                "User compared basic vs pro, mentioned limited budget.",
+                "User requested integration docs and asked about SLA terms.",
+            ],
+            purpose=(
+                "Predict purchase probability; propose only explanatory scalar features (no purchase outcome field)."
+            ),
+        )
+        suggestion = suggester.suggest_schema(data, max_retries=2)
+        self._assert_basic_invariants(self, suggestion)
+        field_names = {f.name for f in suggestion.suggested_schema}
+        forbidden = {"purchase_probability", "will_buy", "purchase_label"}
+        self.assertFalse(field_names & forbidden, f"Forbidden target-like fields present: {field_names & forbidden}")
+        schema_dict = _load_lenient_json(suggestion.json_schema_string)
+        model_cls = deserialize_base_model(schema_dict)
+        self.assertTrue(issubclass(model_cls, BaseModel))
+
+    def test_multiple_example_sets_deserialize(self):
+        """Integration: multiple real prompts must yield JSON schema parsable into a dynamic model."""
+        client = OpenAI()
+        suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+        datasets: List[ExampleData] = [
+            ExampleData(
+                examples=[
+                    "Order #9912 refunded due to damaged item.",
+                    "Order #9913 resolved: replacement shipped.",
+                    "Order #9914 pending investigation about missing parts.",
+                ],
+                purpose="Infer minimal operational status and high-level issue classification for analytics.",
+            ),
+            ExampleData(
+                examples=[
+                    "Rating: 4.5/5 - Fast delivery, packaging slightly dented.",
+                    "Rating: 2/5 - Slow shipping and unresponsive support.",
+                    "Rating: 5/5 - Excellent build quality and service.",
+                ],
+                purpose="Infer numeric rating and sentiment category as flat scalar features.",
+            ),
+            ExampleData(
+                examples=[
+                    "User: can't login after password reset though reset email succeeded.",
+                    "User: login works but dashboard widgets fail to load intermittently.",
+                    "User: account locked after multiple 2FA code failures.",
+                ],
+                purpose="Extract concise issue type classification and any consistently extractable signal.",
+            ),
+        ]
+
+        for data in datasets:
+            suggestion = suggester.suggest_schema(data, max_retries=3)
+            self._assert_basic_invariants(self, suggestion)
+            schema_dict = _load_lenient_json(suggestion.json_schema_string)
+            model_cls = deserialize_base_model(schema_dict)
+            self.assertTrue(issubclass(model_cls, BaseModel))
+            props = model_cls.model_json_schema().get("properties", {})
+            self.assertTrue(props, "expected non-empty properties")
+            for spec in props.values():
+                primitive_types = {"string", "integer", "number", "boolean"}
+                t = spec.get("type")
+                if t is None and "anyOf" in spec:
+                    any_of = spec["anyOf"]
+                    if isinstance(any_of, list) and 1 <= len(any_of) <= 2:
+                        prims = [
+                            x.get("type") for x in any_of if isinstance(x, dict) and x.get("type") in primitive_types
+                        ]
+                        nulls = [x for x in any_of if isinstance(x, dict) and x.get("type") == "null"]
+                        self.assertEqual(len(prims), 1, "unexpected anyOf structure")
+                        self.assertLessEqual(len(nulls), 1, "unexpected anyOf null structure")
+                    else:
+                        self.fail("unexpected anyOf structure for optional primitive")
                 else:
-                    raise AssertionError("unexpected anyOf structure for optional primitive")
-            else:
-                assert t in primitive_types
-            assert "items" not in spec
-            assert spec.get("type") != "object"
-            if "enum" in spec:
-                assert isinstance(spec["enum"], list) and 2 <= len(spec["enum"]) <= 24
+                    self.assertIn(t, primitive_types)
+                self.assertNotIn("items", spec)
+                self.assertNotEqual(spec.get("type"), "object")
+                if "enum" in spec:
+                    self.assertTrue(isinstance(spec["enum"], list) and 2 <= len(spec["enum"]) <= 24)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,235 @@
+from typing import List
+
+from openai import OpenAI
+from pydantic import BaseModel
+
+from openaivec._schema import (  # type: ignore
+    ExampleData,
+    SchemaSuggester,
+    SuggestedSchema,
+    _load_lenient_json,
+    _validate_consistency,
+    materialize_model,
+)
+from openaivec._serialize import deserialize_base_model
+
+
+def _assert_basic_invariants(s: SuggestedSchema) -> None:
+    assert isinstance(s.purpose, str) and s.purpose
+    assert isinstance(s.example_data_description, str) and s.example_data_description
+    assert isinstance(s.suggested_schema, list) and len(s.suggested_schema) > 0
+    names = [f.name for f in s.suggested_schema]
+    assert len(names) == len(set(names)), "field names must be unique"
+    for f in s.suggested_schema:
+        assert f.type in {"string", "integer", "float", "boolean"}
+        assert f.description and isinstance(f.description, str)
+        if f.enum_values is not None:
+            assert f.type == "string"
+            assert 2 <= len(f.enum_values) <= 24
+    schema_dict = _load_lenient_json(s.json_schema_string)
+    _validate_consistency(s, schema_dict)
+
+
+def test_schema_suggester_basic():
+    client = OpenAI()
+    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+    data = ExampleData(
+        examples=[
+            "Order #1234: customer requested refund due to damaged packaging.",
+            "Order #1235: customer happy, praised fast shipping.",
+            "Order #1236: delayed delivery complaint, wants status update.",
+        ],
+        purpose="Extract concise operational signals helpful for simple analytics (issue type, sentiment).",
+    )
+    suggestion = suggester.suggest_schema(data, max_retries=2)
+    _assert_basic_invariants(suggestion)
+
+
+def test_schema_suggester_enum_detection():
+    client = OpenAI()
+    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+    data = ExampleData(
+        examples=[
+            "Absolutely excellent product quality and fantastic support (clearly positive).",
+            "Terrible experience and horrible customer support (clearly negative).",
+            "Average / neutral overall, nothing especially good or bad (clearly neutral).",
+            "Mixed feelings: mostly good build but disappointing battery (mixed).",
+        ],
+        purpose=(
+            "Infer a categorical sentiment_label (small closed enum: e.g. positive, negative, neutral, mixed) "
+            "and any other reliably extractable flat scalar signals. Provide enum values if evident."
+        ),
+    )
+    suggestion = suggester.suggest_schema(data, max_retries=2)
+    _assert_basic_invariants(suggestion)
+    has_enum = any(f.enum_values for f in suggestion.suggested_schema)
+    if not has_enum:
+        sentiment_like = [f for f in suggestion.suggested_schema if "sentiment" in f.name]
+        assert sentiment_like, "expected a sentiment field or an enum with sentiment labels"
+
+
+def test_schema_suggester_materialize_model():
+    client = OpenAI()
+    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+    data = ExampleData(
+        examples=[
+            "Battery life is great and fast charging is helpful.",
+            "Battery drains quickly and overheats sometimes.",
+        ],
+        purpose="Infer sentiment and one or two consistent quality signals as flat scalar fields.",
+    )
+    suggestion = suggester.suggest_schema(data, max_retries=2)
+    model_cls = materialize_model(suggestion)
+    assert issubclass(model_cls, BaseModel)
+    schema = model_cls.model_json_schema()
+    assert "properties" in schema and schema["properties"], "expected non-empty properties"
+
+
+def test_schema_suggester_retry(monkeypatch):  # type: ignore
+    client = OpenAI()
+    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+    data = ExampleData(
+        examples=[
+            "User reported login failure after password reset.",
+            "User confirmed issue was resolved after cache clear.",
+        ],
+        purpose="Extract key status signal (issue vs resolution) as minimal fields.",
+    )
+
+    calls: List[int] = []
+
+    def flaky_once(parsed, schema_dict):  # type: ignore
+        calls.append(1)
+        if len(calls) == 1:
+            raise ValueError("synthetic mismatch to trigger retry")
+        # Succeed silently on subsequent validations (bypass full validation to test retry path)
+        return None
+
+    monkeypatch.setattr("openaivec._schema._validate_consistency", flaky_once)  # type: ignore
+
+    suggestion = suggester.suggest_schema(data, max_retries=3)
+    _assert_basic_invariants(suggestion)
+    assert len(calls) >= 2, "should have retried after induced failure"
+
+
+def test_schema_deserialize_base_model():
+    client = OpenAI()
+    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+    data = ExampleData(
+        examples=[
+            "Great battery life and responsive UI.",
+            "Battery drains fast and UI is sluggish.",
+        ],
+        purpose="Infer sentiment and one reliability signal as flat scalar fields.",
+    )
+    suggestion = suggester.suggest_schema(data, max_retries=2)
+    schema_dict = _load_lenient_json(suggestion.json_schema_string)
+    model_cls = deserialize_base_model(schema_dict)
+    assert issubclass(model_cls, BaseModel)
+    props = model_cls.model_json_schema().get("properties", {})
+    assert list(props.keys()) == [f.name for f in suggestion.suggested_schema]
+
+
+def test_schema_feature_engineering_attrition():
+    client = OpenAI()
+    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+    data = ExampleData(
+        examples=[
+            "Employee notes: workload high, considering options, manager support low.",
+            "Employee notes: satisfied with team collaboration and growth opportunities.",
+            "Employee notes: neutral performance period, seeking clearer career path.",
+        ],
+        purpose=(
+            "Predict employee attrition probability; propose explanatory text-derived features only (no direct target)."
+        ),
+    )
+    suggestion = suggester.suggest_schema(data, max_retries=2)
+    _assert_basic_invariants(suggestion)
+    field_names = {f.name for f in suggestion.suggested_schema}
+    forbidden = {"attrition_probability", "will_leave", "leave_label"}
+    assert not (field_names & forbidden), f"Forbidden target-like fields present: {field_names & forbidden}"
+    # Ensure deserialization still works
+    schema_dict = _load_lenient_json(suggestion.json_schema_string)
+    model_cls = deserialize_base_model(schema_dict)
+    assert issubclass(model_cls, BaseModel)
+
+
+def test_schema_feature_engineering_purchase():
+    client = OpenAI()
+    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+    data = ExampleData(
+        examples=[
+            "User viewed premium plan pricing and asked about discount.",
+            "User compared basic vs pro, mentioned limited budget.",
+            "User requested integration docs and asked about SLA terms.",
+        ],
+        purpose=("Predict purchase probability; propose only explanatory scalar features (no purchase outcome field)."),
+    )
+    suggestion = suggester.suggest_schema(data, max_retries=2)
+    _assert_basic_invariants(suggestion)
+    field_names = {f.name for f in suggestion.suggested_schema}
+    forbidden = {"purchase_probability", "will_buy", "purchase_label"}
+    assert not (field_names & forbidden), f"Forbidden target-like fields present: {field_names & forbidden}"
+    schema_dict = _load_lenient_json(suggestion.json_schema_string)
+    model_cls = deserialize_base_model(schema_dict)
+    assert issubclass(model_cls, BaseModel)
+
+
+def test_schema_multiple_example_sets_deserialize():
+    """Integration: multiple real prompts must yield JSON schema parsable into a dynamic model."""
+    client = OpenAI()
+    suggester = SchemaSuggester(client=client, model_name="gpt-5-mini")
+
+    datasets: List[ExampleData] = [
+        ExampleData(
+            examples=[
+                "Order #9912 refunded due to damaged item.",
+                "Order #9913 resolved: replacement shipped.",
+                "Order #9914 pending investigation about missing parts.",
+            ],
+            purpose="Infer minimal operational status and high-level issue classification for analytics.",
+        ),
+        ExampleData(
+            examples=[
+                "Rating: 4.5/5 - Fast delivery, packaging slightly dented.",
+                "Rating: 2/5 - Slow shipping and unresponsive support.",
+                "Rating: 5/5 - Excellent build quality and service.",
+            ],
+            purpose="Infer numeric rating and sentiment category as flat scalar features.",
+        ),
+        ExampleData(
+            examples=[
+                "User: can't login after password reset though reset email succeeded.",
+                "User: login works but dashboard widgets fail to load intermittently.",
+                "User: account locked after multiple 2FA code failures.",
+            ],
+            purpose="Extract concise issue type classification and any consistently extractable signal.",
+        ),
+    ]
+
+    for data in datasets:
+        suggestion = suggester.suggest_schema(data, max_retries=3)
+        _assert_basic_invariants(suggestion)
+        schema_dict = _load_lenient_json(suggestion.json_schema_string)
+        model_cls = deserialize_base_model(schema_dict)
+        assert issubclass(model_cls, BaseModel)
+        props = model_cls.model_json_schema().get("properties", {})
+        assert props, "expected non-empty properties"
+        for spec in props.values():
+            primitive_types = {"string", "integer", "number", "boolean"}
+            t = spec.get("type")
+            if t is None and "anyOf" in spec:
+                # Accept optional pattern anyOf [primitive, null]
+                any_of = spec["anyOf"]
+                if isinstance(any_of, list) and 1 <= len(any_of) <= 2:
+                    prims = [x.get("type") for x in any_of if isinstance(x, dict) and x.get("type") in primitive_types]
+                    nulls = [x for x in any_of if isinstance(x, dict) and x.get("type") == "null"]
+                    assert len(prims) == 1 and len(nulls) <= 1, "unexpected anyOf structure"
+                else:
+                    raise AssertionError("unexpected anyOf structure for optional primitive")
+            else:
+                assert t in primitive_types
+            assert "items" not in spec
+            assert spec.get("type") != "object"
+            if "enum" in spec:
+                assert isinstance(spec["enum"], list) and 2 <= len(spec["enum"]) <= 24


### PR DESCRIPTION
This pull request introduces a major update to testing guidelines and adds a new internal module for schema inference. The documentation now encourages using live OpenAI/Azure API calls in unit tests where practical, with detailed rules for when to use mocks, how to handle determinism, and how to manage cost and flakiness. Additionally, a new internal module, `_schema.py`, implements a robust schema inference engine using Pydantic models, dynamic field typing (including enums), and OpenAI's structured parsing API.

**Testing Policy & Documentation Updates:**

* The `.github/copilot-instructions.md` file now mandates that unit tests should use real OpenAI/Azure APIs whenever feasible, outlining strict guidelines for when to use live calls, how to handle cost and determinism, and how to structure and skip tests based on environment configuration. Mocking is now reserved for specific cases such as fault injection or when determinism cannot be maintained.
* The PR checklist and documentation have been updated to reflect this new testing policy, requiring justification for any use of mocks and ensuring live API tests are skipped gracefully if credentials are missing.
* Minor clarifications and formatting improvements to package visibility and API documentation.

**New Internal Schema Inference Module:**

* Added `src/openaivec/_schema.py`, which introduces:
  - `FieldSpec` and `InferredSchema` Pydantic models for describing inferred field structures and extraction prompts.
  - `SchemaInferer` dataclass for inferring and materializing dynamic Pydantic models from representative examples using OpenAI's structured parsing API, including robust retry and validation logic.
  - Dynamic enum class generation for categorical fields and comprehensive validation of inferred schemas.