### PR TITLE
refactor: rename variable

### DIFF
--- a/src/openaivec/_schema.py
+++ b/src/openaivec/_schema.py
@@ -1,7 +1,7 @@
 """Internal schema inference & dynamic model materialization utilities.
 
 This (non-public) module converts a small *representative* sample of free‑text
-examples plus a *purpose* statement into:
+examples plus an *instructions* statement into:
 
 1. A vetted hierarchical object specification (``ObjectSpec``) whose recursively
      defined ``fields`` (``FieldSpec``) capture reliably extractable signals.
@@ -45,7 +45,7 @@ Example (conceptual):
         schema = inferer.infer_schema(
                 SchemaInferenceInput(
                         examples=["Order #123 delayed due to weather", "Order #456 delivered"],
-                        purpose="Extract operational status signals for logistics analytics",
+                        instructions="Extract operational status signals for logistics analytics",
                 )
         )
         Model = schema.model  # dynamic Pydantic model
@@ -71,16 +71,16 @@ __all__: list[str] = []
 class InferredSchema(BaseModel):
     """Result of a schema inference round.
 
-    Contains the normalized *purpose*, objective *examples_summary*, the root
+    Contains the normalized *instructions*, objective *examples_summary*, the root
     hierarchical ``object_spec`` contract, and the canonical reusable
     ``inference_prompt``. The prompt MUST be fully derivable from the other
     components (no new unstated facts) to preserve traceability.
 
     Attributes:
-        purpose: Unambiguous restatement of the user's objective.
+        instructions: Unambiguous restatement of the user's objective.
         examples_summary: Neutral description of structural / semantic patterns
             observed in the examples.
-        examples_purpose_alignment: Mapping from purpose facets to concrete
+        examples_instructions_alignment: Mapping from instructions facets to concrete
             recurring evidence (or explicit gaps) anchoring extraction scope.
         object_spec: Root ``ObjectSpec`` (UpperCamelCase name) whose ``fields``
             recursively define the extraction schema.
@@ -88,7 +88,7 @@ class InferredSchema(BaseModel):
             hierarchy, and types (no additions/removals/renames).
     """
 
-    purpose: str = Field(
+    instructions: str = Field(
         description=(
             "Normalized, unambiguous restatement of the user objective with redundant, vague, or "
             "conflicting phrasing removed."
@@ -100,24 +100,25 @@ class InferredSchema(BaseModel):
             "patterns, and notable constraints."
         )
     )
-    examples_purpose_alignment: str = Field(
+    examples_instructions_alignment: str = Field(
         description=(
             "Explanation of how observable recurring patterns in the examples substantiate and bound the stated "
-            "purpose. Should reference purpose facets and cite supporting example evidence (or note any gaps) to "
-            "reduce hallucinated fields. Internal diagnostic / quality aid; not required for downstream extraction."
+            "instructions. Should reference instructions facets and cite supporting example evidence (or note any "
+            "gaps) to reduce hallucinated fields. Internal diagnostic / quality aid; not required for downstream "
+            "extraction."
         )
     )
     object_spec: ObjectSpec = Field(
         description=(
             "Root ObjectSpec (recursive). Each contained object's field list is unique-name ordered and derived "
-            "strictly from observable, repeatable signals aligned with the purpose."
+            "strictly from observable, repeatable signals aligned with the instructions."
         )
     )
     inference_prompt: str = Field(
         description=(
-            "Canonical, reusable extraction prompt. Must be derivable from purpose + summaries + object_spec. Enforces "
-            "exact hierarchical field set (names, order per object, types) forbidding additions, removals, renames, or "
-            "subjective language. Self-contained (no TODOs, external refs, or placeholders)."
+            "Canonical, reusable extraction prompt. Must be derivable from instructions + summaries + object_spec. "
+            "Enforces exact hierarchical field set (names, order per object, types) forbidding additions, removals, "
+            "renames, or subjective language. Self-contained (no TODOs, external refs, or placeholders)."
         )
     )
 
@@ -176,7 +177,7 @@ class SchemaInferenceInput(BaseModel):
         examples: Representative sample texts restricted to the in‑scope
             distribution (exclude outliers / noise). Size should be *minimal*
             yet sufficient to surface recurring patterns.
-        purpose: Plain language description of downstream usage (analytics,
+        instructions: Plain language description of downstream usage (analytics,
             filtering, enrichment, feature engineering, etc.). Guides field
             relevance & exclusion of outcome labels.
     """
@@ -187,7 +188,7 @@ class SchemaInferenceInput(BaseModel):
             "exclude outliers not in scope."
         )
     )
-    purpose: str = Field(
+    instructions: str = Field(
         description=(
             "Plain language statement describing the downstream use of the extracted structured data (e.g. "
             "analytics, filtering, enrichment)."
@@ -199,15 +200,16 @@ _INFER_INSTRUCTIONS = """
 You are a schema inference engine.
 
 Task:
-1. Normalize the user's purpose (eliminate ambiguity, redundancy, contradictions).
+1. Normalize the user's instructions (eliminate ambiguity, redundancy, contradictions).
 2. Objectively summarize observable patterns in the example texts.
-3. Produce an "examples_purpose_alignment" explanation mapping purpose facets to concrete recurring evidence (or gaps).
+3. Produce an "examples_instructions_alignment" explanation mapping instructions facets to concrete recurring
+     evidence (or gaps).
 4. Propose a minimal hierarchical schema (root ObjectSpec) comprised of reliably extractable fields. Use nesting ONLY
      when a group of fields forms a cohesive sub-entity repeated in the data; otherwise keep flat.
 5. Skip fields likely missing in a large share (>~20%) of realistic inputs.
 6. Provide enum_spec ONLY when a small stable closed categorical set (1–{_MAX_ENUM_VALUES} raw tokens) is clearly
      evidenced; never invent unseen categories.
-7. If the purpose indicates prediction (predict / probability / likelihood),
+7. If the instructions indicate prediction (predict / probability / likelihood),
    output only explanatory features (no target restatement).
 
 Rules:
@@ -229,9 +231,9 @@ Rules:
 
 Output contract:
 Return exactly an InferredSchema JSON object with keys:
-        - purpose (string)
+        - instructions (string)
         - examples_summary (string)
-        - examples_purpose_alignment (string)
+        - examples_instructions_alignment (string)
         - object_spec (ObjectSpec: name, fields[list[FieldSpec]])
         - inference_prompt (string)
 Where each FieldSpec includes: name, type, description, optional enum_spec (for
@@ -272,14 +274,14 @@ class SchemaInferer:
                 3. Retry (up to ``max_retries``) on validation failure.
 
         Args:
-            data (SchemaInferenceInput): Representative examples + purpose.
+            data (SchemaInferenceInput): Representative examples + instructions.
             *args: Positional passthrough to ``client.responses.parse``.
             max_retries (int, optional): Attempts before surfacing the last validation error
                 (must be >= 1). Defaults to 3.
             **kwargs: Keyword passthrough to ``client.responses.parse``.
 
         Returns:
-            InferredSchema: Fully validated schema (purpose, examples summary,
+            InferredSchema: Fully validated schema (instructions, examples summary,
             ordered fields, extraction prompt).
 
         Raises:

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -453,7 +453,7 @@ class OpenAIVecSeriesAccessor:
     ) -> pd.Series:
         """Parse Series values using an LLM with a provided cache.
         This method allows you to parse the Series content into structured data
-        using an LLM, optionally inferring a schema based on the provided purpose.
+        using an LLM, optionally inferring a schema based on the provided instructions.
 
         Args:
             instructions (str): System prompt for the LLM.
@@ -475,7 +475,7 @@ class OpenAIVecSeriesAccessor:
 
         schema: InferredSchema | None = None
         if response_format is None:
-            schema = self.infer_schema(purpose=instructions, max_examples=max_examples, **api_kwargs)
+            schema = self.infer_schema(instructions=instructions, max_examples=max_examples, **api_kwargs)
 
         return self.responses_with_cache(
             instructions=schema.inference_prompt if schema else instructions,
@@ -500,7 +500,7 @@ class OpenAIVecSeriesAccessor:
         """Parse Series values using an LLM with optional schema inference.
 
         This method allows you to parse the Series content into structured data
-        using an LLM, optionally inferring a schema based on the provided purpose.
+        using an LLM, optionally inferring a schema based on the provided instructions.
 
         Args:
             instructions (str): System prompt for the LLM.
@@ -529,7 +529,7 @@ class OpenAIVecSeriesAccessor:
             **api_kwargs,
         )
 
-    def infer_schema(self, purpose: str, max_examples: int = 100, **api_kwargs) -> InferredSchema:
+    def infer_schema(self, instructions: str, max_examples: int = 100, **api_kwargs) -> InferredSchema:
         """Infer a structured data schema from Series content using AI.
 
         This method analyzes a sample of the Series values to automatically infer
@@ -538,7 +538,7 @@ class OpenAIVecSeriesAccessor:
         potential enum values based on patterns found in the data.
 
         Args:
-            purpose (str): Plain language description of how the extracted
+            instructions (str): Plain language description of how the extracted
                 structured data will be used (e.g., "Extract customer sentiment
                 signals for analytics", "Parse product features for search").
                 This guides field relevance and helps exclude irrelevant information.
@@ -548,7 +548,7 @@ class OpenAIVecSeriesAccessor:
 
         Returns:
             InferredSchema: An object containing:
-                - purpose: Normalized statement of the extraction objective
+                - instructions: Normalized statement of the extraction objective
                 - fields: List of field specifications with names, types, and descriptions
                 - inference_prompt: Reusable prompt for future extractions
                 - model: Dynamically generated Pydantic model for parsing
@@ -564,7 +564,7 @@ class OpenAIVecSeriesAccessor:
 
             # Infer schema for sentiment analysis
             schema = reviews.ai.infer_schema(
-                purpose="Extract sentiment and product quality indicators"
+                instructions="Extract sentiment and product quality indicators"
             )
 
             # Use the inferred schema for batch extraction
@@ -580,7 +580,9 @@ class OpenAIVecSeriesAccessor:
         inferer = CONTAINER.resolve(SchemaInferer)
 
         input: SchemaInferenceInput = SchemaInferenceInput(
-            examples=self._obj.sample(n=min(max_examples, len(self._obj))).tolist(), purpose=purpose, **api_kwargs
+            examples=self._obj.sample(n=min(max_examples, len(self._obj))).tolist(),
+            instructions=instructions,
+            **api_kwargs,
         )
         return inferer.infer_schema(input)
 
@@ -844,7 +846,7 @@ class OpenAIVecDataFrameAccessor:
 
         This method allows you to parse each DataFrame row (serialized as JSON)
         into structured data using an LLM, optionally inferring a schema based
-        on the provided purpose.
+        on the provided instructions.
 
         Args:
             instructions (str): System prompt for the LLM.
@@ -890,7 +892,7 @@ class OpenAIVecDataFrameAccessor:
 
         This method allows you to parse each DataFrame row (serialized as JSON)
         into structured data using an LLM, optionally inferring a schema based
-        on the provided purpose.
+        on the provided instructions.
 
         Args:
             instructions (str): System prompt for the LLM.
@@ -919,7 +921,7 @@ class OpenAIVecDataFrameAccessor:
             **api_kwargs,
         )
 
-    def infer_schema(self, purpose: str, max_examples: int = 100) -> InferredSchema:
+    def infer_schema(self, instructions: str, max_examples: int = 100) -> InferredSchema:
         """Infer a structured data schema from DataFrame rows using AI.
 
         This method analyzes a sample of DataFrame rows to automatically infer
@@ -928,7 +930,7 @@ class OpenAIVecDataFrameAccessor:
         field types, and potential categorical values.
 
         Args:
-            purpose (str): Plain language description of how the extracted
+            instructions (str): Plain language description of how the extracted
                 structured data will be used (e.g., "Extract operational metrics
                 for dashboard", "Parse customer attributes for segmentation").
                 This guides field relevance and helps exclude irrelevant information.
@@ -938,7 +940,7 @@ class OpenAIVecDataFrameAccessor:
 
         Returns:
             InferredSchema: An object containing:
-                - purpose: Normalized statement of the extraction objective
+                - instructions: Normalized statement of the extraction objective
                 - fields: List of field specifications with names, types, and descriptions
                 - inference_prompt: Reusable prompt for future extractions
                 - model: Dynamically generated Pydantic model for parsing
@@ -957,7 +959,7 @@ class OpenAIVecDataFrameAccessor:
 
             # Infer schema for logistics tracking
             schema = df.ai.infer_schema(
-                purpose="Extract shipping status and location data for logistics tracking"
+                instructions="Extract shipping status and location data for logistics tracking"
             )
 
             # Apply the schema to extract structured data
@@ -971,7 +973,7 @@ class OpenAIVecDataFrameAccessor:
             Spark operations.
         """
         return _df_rows_to_json_series(self._obj).ai.infer_schema(
-            purpose=purpose,
+            instructions=instructions,
             max_examples=max_examples,
         )
 
@@ -1477,7 +1479,7 @@ class AsyncOpenAIVecSeriesAccessor:
         """Parse Series values using an LLM with a provided cache (asynchronously).
 
         This method allows you to parse the Series content into structured data
-        using an LLM, optionally inferring a schema based on the provided purpose.
+        using an LLM, optionally inferring a schema based on the provided instructions.
 
         Args:
             instructions (str): System prompt for the LLM.
@@ -1504,7 +1506,7 @@ class AsyncOpenAIVecSeriesAccessor:
         schema: InferredSchema | None = None
         if response_format is None:
             # Use synchronous schema inference
-            schema = self._obj.ai.infer_schema(purpose=instructions, max_examples=max_examples)
+            schema = self._obj.ai.infer_schema(instructions=instructions, max_examples=max_examples)
 
         return await self.responses_with_cache(
             instructions=schema.inference_prompt if schema else instructions,
@@ -1530,7 +1532,7 @@ class AsyncOpenAIVecSeriesAccessor:
         """Parse Series values using an LLM with optional schema inference (asynchronously).
 
         This method allows you to parse the Series content into structured data
-        using an LLM, optionally inferring a schema based on the provided purpose.
+        using an LLM, optionally inferring a schema based on the provided instructions.
 
         Args:
             instructions (str): System prompt for the LLM.
@@ -1807,7 +1809,7 @@ class AsyncOpenAIVecDataFrameAccessor:
 
         This method allows you to parse each DataFrame row (serialized as JSON)
         into structured data using an LLM, optionally inferring a schema based
-        on the provided purpose.
+        on the provided instructions.
 
         Args:
             instructions (str): System prompt for the LLM.
@@ -1857,7 +1859,7 @@ class AsyncOpenAIVecDataFrameAccessor:
 
         This method allows you to parse each DataFrame row (serialized as JSON)
         into structured data using an LLM, optionally inferring a schema based
-        on the provided purpose.
+        on the provided instructions.
 
         Args:
             instructions (str): System prompt for the LLM.

--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -545,7 +545,7 @@ def infer_schema(
     )
 
     input = SchemaInferenceInput(
-        purpose=instructions,
+        instructions=instructions,
         examples=examples,
     )
     inferer = CONTAINER.resolve(SchemaInferer)

--- a/tests/test_pandas_ext.py
+++ b/tests/test_pandas_ext.py
@@ -70,7 +70,7 @@ class TestPandasExt:
             ]
         )
 
-        schema = reviews.ai.infer_schema(purpose="Extract product review analysis data", max_examples=3)
+        schema = reviews.ai.infer_schema(instructions="Extract product review analysis data", max_examples=3)
 
         assert schema is not None
         assert schema.model is not None
@@ -124,7 +124,7 @@ class TestPandasExt:
             ]
         )
 
-        schema = df.ai.infer_schema(purpose="Extract product analysis metrics", max_examples=2)
+        schema = df.ai.infer_schema(instructions="Extract product analysis metrics", max_examples=2)
 
         assert schema is not None
         assert schema.model is not None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,14 +18,14 @@ def cached_inferred_schemas(openai_client, responses_model_name):
                 "Order #1235: customer happy, praised fast shipping.",
                 "Order #1236: delayed delivery complaint, wants status update.",
             ],
-            purpose="Extract useful flat analytic signals from short support notes.",
+            instructions="Extract useful flat analytic signals from short support notes.",
         ),
         "retry_case": SchemaInferenceInput(
             examples=[
                 "User reported login failure after password reset.",
                 "User confirmed issue was resolved after cache clear.",
             ],
-            purpose="Infer minimal status/phase signals from event style notes.",
+            instructions="Infer minimal status/phase signals from event style notes.",
         ),
     }
 
@@ -137,9 +137,9 @@ class TestInferredSchemaBuildModel:
     def test_build_model_primitive_types(self):
         """Test that all primitive types are correctly mapped to Python types."""
         schema = InferredSchema(
-            purpose="Test primitive types",
+            instructions="Test primitive types",
             examples_summary="Various primitive type examples",
-            examples_purpose_alignment="Primitive examples justify coverage of all base types",
+            examples_instructions_alignment="Primitive examples justify coverage of all base types",
             object_spec=ObjectSpec(
                 name="PrimitiveRoot",
                 fields=[
@@ -168,9 +168,9 @@ class TestInferredSchemaBuildModel:
     def test_build_model_enum_field(self):
         """Test that enum fields generate proper Enum classes."""
         schema = InferredSchema(
-            purpose="Test enum types",
+            instructions="Test enum types",
             examples_summary="Enum examples",
-            examples_purpose_alignment="Stable status labels appear repeatedly, supporting enum creation",
+            examples_instructions_alignment="Stable status labels appear repeatedly, supporting enum creation",
             object_spec=ObjectSpec(
                 name="EnumRoot",
                 fields=[
@@ -208,9 +208,9 @@ class TestInferredSchemaBuildModel:
         ]
 
         schema = InferredSchema(
-            purpose="Test field ordering",
+            instructions="Test field ordering",
             examples_summary="Field ordering examples",
-            examples_purpose_alignment="Ordering matters for deterministic downstream column alignment",
+            examples_instructions_alignment="Ordering matters for deterministic downstream column alignment",
             object_spec=ObjectSpec(name="OrderingRoot", fields=fields),
             inference_prompt="Test prompt",
         )
@@ -224,9 +224,9 @@ class TestInferredSchemaBuildModel:
     def test_build_model_field_descriptions(self):
         """Test that field descriptions are correctly included in the model."""
         schema = InferredSchema(
-            purpose="Test field descriptions",
+            instructions="Test field descriptions",
             examples_summary="Description examples",
-            examples_purpose_alignment="Descriptions guide extraction disambiguation",
+            examples_instructions_alignment="Descriptions guide extraction disambiguation",
             object_spec=ObjectSpec(
                 name="DescRoot",
                 fields=[
@@ -247,9 +247,9 @@ class TestInferredSchemaBuildModel:
     def test_build_model_empty_fields(self):
         """Test behavior with empty fields list."""
         schema = InferredSchema(
-            purpose="Test empty fields",
+            instructions="Test empty fields",
             examples_summary="Empty examples",
-            examples_purpose_alignment="Edge case of no extractable signals",
+            examples_instructions_alignment="Edge case of no extractable signals",
             object_spec=ObjectSpec(name="EmptyRoot", fields=[]),
             inference_prompt="Test prompt",
         )
@@ -267,9 +267,9 @@ class TestInferredSchemaBuildModel:
     def test_build_model_mixed_enum_and_regular_fields(self):
         """Test a complex scenario with both enum and regular fields of all types."""
         schema = InferredSchema(
-            purpose="Test mixed field types",
+            instructions="Test mixed field types",
             examples_summary="Mixed type examples",
-            examples_purpose_alignment="Examples demonstrate diverse field types including enums",
+            examples_instructions_alignment="Examples demonstrate diverse field types including enums",
             object_spec=ObjectSpec(
                 name="MixedRoot",
                 fields=[
@@ -314,9 +314,9 @@ class TestInferredSchemaBuildModel:
     def test_build_model_multiple_calls_independence(self):
         """Test that multiple calls to build_model return independent model classes."""
         schema = InferredSchema(
-            purpose="Test independence",
+            instructions="Test independence",
             examples_summary="Independence examples",
-            examples_purpose_alignment="Independence ensures rebuilding yields fresh class objects",
+            examples_instructions_alignment="Independence ensures rebuilding yields fresh class objects",
             object_spec=ObjectSpec(
                 name="IndependentRoot",
                 fields=[
@@ -339,9 +339,9 @@ class TestInferredSchemaBuildModel:
     def test_build_model_array_types(self):
         """Test that *_array types map to list element annotations and proper JSON Schema arrays."""
         schema = InferredSchema(
-            purpose="Test array types",
+            instructions="Test array types",
             examples_summary="Array type examples",
-            examples_purpose_alignment="Examples justify homogeneous primitive arrays",
+            examples_instructions_alignment="Examples justify homogeneous primitive arrays",
             object_spec=ObjectSpec(
                 name="ArrayRoot",
                 fields=[


### PR DESCRIPTION
close: #62 

This pull request standardizes the terminology used for schema inference across the codebase, replacing the term "purpose" with "instructions" in both internal logic and user-facing documentation. This change improves clarity and consistency for users and developers working with schema inference and parsing functionality.

**Schema inference and model definitions:**

* Replaced the `purpose` field with `instructions` in the `InferredSchema` and `SchemaInferenceInput` models, updating all related attribute names, descriptions, and usage throughout `src/openaivec/_schema.py`. [[1]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L4-R4) [[2]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L48-R48) [[3]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L74-R91) [[4]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L103-R121) [[5]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L179-R180) [[6]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L190-R191) [[7]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L202-R212) [[8]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L232-R236) [[9]](diffhunk://#diff-d57b4de127caa54bd74b0819e81d457e1d6331a7242dd4a3cc07a3b789623f68L275-R284)

**Pandas extension interface and documentation:**

* Updated all method signatures and docstrings in `src/openaivec/pandas_ext.py` to use `instructions` instead of `purpose` for schema inference and parsing, ensuring consistency in both synchronous and asynchronous methods. [[1]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L456-R456) [[2]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L478-R478) [[3]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L503-R503) [[4]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L532-R532) [[5]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L541-R541) [[6]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L551-R551) [[7]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L567-R567) [[8]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L583-R585) [[9]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L847-R849) [[10]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L893-R895) [[11]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L922-R924) [[12]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L931-R933) [[13]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L941-R943) [[14]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L960-R962) [[15]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L974-R976) [[16]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L1480-R1482) [[17]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L1507-R1509) [[18]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L1533-R1535)

These updates ensure that the concept of "instructions" is used consistently throughout the schema inference workflow, improving clarity for both developers and end users.