### PR TITLE
Refactor/kwargs

### DIFF
--- a/src/openaivec/_embeddings.py
+++ b/src/openaivec/_embeddings.py
@@ -33,7 +33,7 @@ class BatchEmbeddings:
     cache: BatchingMapProxy[str, NDArray[np.float32]] = field(default_factory=lambda: BatchingMapProxy(batch_size=None))
 
     @classmethod
-    def of(cls, client: OpenAI, model_name: str, batch_size: int | None = None, **api_kwargs) -> "BatchEmbeddings":
+    def of(cls, client: OpenAI, model_name: str, batch_size: int | None = None) -> "BatchEmbeddings":
         """Factory constructor.
 
         Args:
@@ -41,19 +41,15 @@ class BatchEmbeddings:
             model_name (str): For Azure OpenAI, use your deployment name. For OpenAI, use the model name.
             batch_size (int | None, optional): Max unique inputs per API call. Defaults to None
                 (automatic batch size optimization). Set to a positive integer for fixed batch size.
-            **api_kwargs: Additional OpenAI API parameters (e.g., dimensions for text-embedding-3 models).
 
         Returns:
             BatchEmbeddings: Configured instance backed by a batching proxy.
         """
-        instance = cls(client=client, model_name=model_name, cache=BatchingMapProxy(batch_size=batch_size))
-        # Store api_kwargs for use in _embed_chunk
-        object.__setattr__(instance, "_api_kwargs", api_kwargs)
-        return instance
+        return cls(client=client, model_name=model_name, cache=BatchingMapProxy(batch_size=batch_size))
 
     @observe(_LOGGER)
     @backoff(exceptions=[RateLimitError, InternalServerError], scale=1, max_retries=12)
-    def _embed_chunk(self, inputs: list[str], **extra_api_params) -> list[NDArray[np.float32]]:
+    def _embed_chunk(self, inputs: list[str], **api_kwargs) -> list[NDArray[np.float32]]:
         """Embed one minibatch of strings.
 
         This private helper is the unit of work used by the map/parallel
@@ -62,22 +58,13 @@ class BatchEmbeddings:
 
         Args:
             inputs (list[str]): Input strings to be embedded. Duplicates allowed.
-            **extra_api_params: Additional API parameters to override stored ones.
+            **api_kwargs: Additional API parameters to override stored ones.
 
         Returns:
             list[NDArray[np.float32]]: Embedding vectors aligned to ``inputs``.
         """
-        # Build base API parameters
-        api_params = {"input": inputs, "model": self.model_name}
 
-        # Merge stored api_kwargs first (from constructor)
-        if hasattr(self, "_api_kwargs"):
-            api_params.update(self._api_kwargs)
-
-        # Then merge extra_api_params (caller can override)
-        api_params.update(extra_api_params)
-
-        responses = self.client.embeddings.create(**api_params)
+        responses = self.client.embeddings.create(input=inputs, model=self.model_name, **api_kwargs)
         return [np.array(d.embedding, dtype=np.float32) for d in responses.data]
 
     @observe(_LOGGER)
@@ -174,7 +161,7 @@ class AsyncBatchEmbeddings:
 
     @backoff_async(exceptions=[RateLimitError, InternalServerError], scale=1, max_retries=12)
     @observe(_LOGGER)
-    async def _embed_chunk(self, inputs: list[str]) -> list[NDArray[np.float32]]:
+    async def _embed_chunk(self, inputs: list[str], **api_kwargs) -> list[NDArray[np.float32]]:
         """Embed one minibatch of strings asynchronously.
 
         This private helper handles the actual API call for a batch of inputs.
@@ -183,6 +170,7 @@ class AsyncBatchEmbeddings:
 
         Args:
             inputs (list[str]): Input strings to be embedded. Duplicates allowed.
+            **api_kwargs: Additional API parameters to override stored ones.
 
         Returns:
             list[NDArray[np.float32]]: Embedding vectors aligned to ``inputs``.
@@ -190,7 +178,7 @@ class AsyncBatchEmbeddings:
         Raises:
             RateLimitError: Propagated if retries are exhausted.
         """
-        responses = await self.client.embeddings.create(input=inputs, model=self.model_name)
+        responses = await self.client.embeddings.create(input=inputs, model=self.model_name, **api_kwargs)
         return [np.array(d.embedding, dtype=np.float32) for d in responses.data]
 
     @observe(_LOGGER)

--- a/src/openaivec/_model.py
+++ b/src/openaivec/_model.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 
 __all__ = [
@@ -14,7 +14,7 @@ class PreparedTask(Generic[ResponseFormat]):
 
     This class encapsulates all the necessary parameters for executing a task,
     including the instructions to be sent to the model, the expected response
-    format using Pydantic models, and sampling parameters for controlling
+    format using Pydantic models, and API parameters for controlling
     the model's output behavior.
 
     Attributes:
@@ -22,12 +22,9 @@ class PreparedTask(Generic[ResponseFormat]):
             This should contain clear, specific directions for the task.
         response_format (type[ResponseFormat]): A Pydantic model class or str type that defines the expected
             structure of the response. Can be either a BaseModel subclass or str.
-        temperature (float): Controls randomness in the model's output.
-            Range: 0.0 to 1.0. Lower values make output more deterministic.
-            Defaults to 0.0.
-        top_p (float): Controls diversity via nucleus sampling. Only tokens
-            comprising the top_p probability mass are considered.
-            Range: 0.0 to 1.0. Defaults to 1.0.
+        api_kwargs (dict[str, int | float | str | bool]): Additional OpenAI API parameters
+            such as temperature, top_p, frequency_penalty, presence_penalty, seed, etc.
+            Defaults to an empty dict.
 
     Example:
         Creating a custom task:
@@ -43,8 +40,7 @@ class PreparedTask(Generic[ResponseFormat]):
         custom_task = PreparedTask(
             instructions="Translate the following text to French:",
             response_format=TranslationResponse,
-            temperature=0.1,
-            top_p=0.9
+            api_kwargs={"temperature": 0.1, "top_p": 0.9}
         )
         ```
 
@@ -55,8 +51,7 @@ class PreparedTask(Generic[ResponseFormat]):
 
     instructions: str
     response_format: type[ResponseFormat]
-    temperature: float = 0.0
-    top_p: float = 1.0
+    api_kwargs: dict[str, int | float | str | bool] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/src/openaivec/_prompt.py
+++ b/src/openaivec/_prompt.py
@@ -445,8 +445,7 @@ class FewShotPromptBuilder:
         self,
         client: OpenAI | None = None,
         model_name: str | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
+        **api_kwargs,
     ) -> "FewShotPromptBuilder":
         """Iteratively refine the prompt using an LLM.
 
@@ -460,8 +459,7 @@ class FewShotPromptBuilder:
         Args:
             client (OpenAI | None): Configured OpenAI client. If None, uses DI container with environment variables.
             model_name (str | None): Model identifier. If None, uses default ``gpt-4.1-mini``.
-            temperature (float | None): Sampling temperature. If None, uses model default.
-            top_p (float | None): Nucleus sampling parameter. If None, uses model default.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, etc.).
 
         Returns:
             FewShotPromptBuilder: The current builder instance containing the refined prompt and iteration history.
@@ -479,9 +477,8 @@ class FewShotPromptBuilder:
             model=_model_name,
             instructions=_PROMPT,
             input=Request(prompt=self._prompt).model_dump_json(),
-            temperature=temperature,
-            top_p=top_p,
             text_format=Response,
+            **api_kwargs,
         )
 
         # keep the original prompt

--- a/src/openaivec/_schema.py
+++ b/src/openaivec/_schema.py
@@ -154,7 +154,9 @@ class InferredSchema(BaseModel):
             PreparedTask: Ready for batched structured extraction calls.
         """
         return PreparedTask(
-            instructions=self.inference_prompt, response_format=self.model, top_p=None, temperature=None
+            instructions=self.inference_prompt,
+            response_format=self.model,
+            api_kwargs={"top_p": None, "temperature": None},
         )
 
     def build_model(self) -> type[BaseModel]:

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -435,7 +435,7 @@ class OpenAIVecSeriesAccessor:
         self,
         instructions: str,
         cache: BatchingMapProxy[str, ResponseFormat],
-        response_format: ResponseFormat = None,
+        response_format: type[ResponseFormat] | None = None,
         max_examples: int = 100,
         **api_kwargs,
     ) -> pd.Series:
@@ -447,7 +447,7 @@ class OpenAIVecSeriesAccessor:
             instructions (str): System prompt for the LLM.
             cache (BatchingMapProxy[str, BaseModel]): Explicit cache instance for
                 batching and deduplication control.
-            response_format (type[BaseModel] | None): Pydantic model or built-in type
+            response_format (type[ResponseFormat] | None): Pydantic model or built-in type
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
@@ -474,7 +474,7 @@ class OpenAIVecSeriesAccessor:
     def parse(
         self,
         instructions: str,
-        response_format: ResponseFormat = None,
+        response_format: type[ResponseFormat] | None = None,
         max_examples: int = 100,
         batch_size: int | None = None,
         show_progress: bool = False,
@@ -487,7 +487,7 @@ class OpenAIVecSeriesAccessor:
 
         Args:
             instructions (str): System prompt for the LLM.
-            response_format (type[BaseModel] | None): Pydantic model or built-in type
+            response_format (type[ResponseFormat] | None): Pydantic model or built-in type
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
@@ -800,7 +800,7 @@ class OpenAIVecDataFrameAccessor:
         self,
         instructions: str,
         cache: BatchingMapProxy[str, ResponseFormat],
-        response_format: ResponseFormat = None,
+        response_format: type[ResponseFormat] | None = None,
         max_examples: int = 100,
         **api_kwargs,
     ) -> pd.Series:
@@ -814,7 +814,7 @@ class OpenAIVecDataFrameAccessor:
             instructions (str): System prompt for the LLM.
             cache (BatchingMapProxy[str, ResponseFormat]): Explicit cache instance for
                 batching and deduplication control.
-            response_format (type[BaseModel] | None): Pydantic model or built-in type
+            response_format (type[ResponseFormat] | None): Pydantic model or built-in type
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
@@ -839,7 +839,7 @@ class OpenAIVecDataFrameAccessor:
     def parse(
         self,
         instructions: str,
-        response_format: ResponseFormat = None,
+        response_format: type[ResponseFormat] | None = None,
         max_examples: int = 100,
         batch_size: int | None = None,
         show_progress: bool = False,
@@ -853,7 +853,7 @@ class OpenAIVecDataFrameAccessor:
 
         Args:
             instructions (str): System prompt for the LLM.
-            response_format (type[BaseModel] | None): Pydantic model or built-in type
+            response_format (type[ResponseFormat] | None): Pydantic model or built-in type
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
@@ -1410,7 +1410,7 @@ class AsyncOpenAIVecSeriesAccessor:
         self,
         instructions: str,
         cache: AsyncBatchingMapProxy[str, ResponseFormat],
-        response_format: ResponseFormat = None,
+        response_format: type[ResponseFormat] | None = None,
         max_examples: int = 100,
         **api_kwargs,
     ) -> pd.Series:
@@ -1423,7 +1423,7 @@ class AsyncOpenAIVecSeriesAccessor:
             instructions (str): System prompt for the LLM.
             cache (AsyncBatchingMapProxy[str, ResponseFormat]): Explicit cache instance for
                 batching and deduplication control.
-            response_format (type[BaseModel] | None): Pydantic model or built-in type
+            response_format (type[ResponseFormat] | None): Pydantic model or built-in type
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
@@ -1455,7 +1455,7 @@ class AsyncOpenAIVecSeriesAccessor:
     async def parse(
         self,
         instructions: str,
-        response_format: ResponseFormat = None,
+        response_format: type[ResponseFormat] | None = None,
         max_examples: int = 100,
         batch_size: int | None = None,
         max_concurrency: int = 8,
@@ -1469,7 +1469,7 @@ class AsyncOpenAIVecSeriesAccessor:
 
         Args:
             instructions (str): System prompt for the LLM.
-            response_format (type[BaseModel] | None): Pydantic model or built-in type
+            response_format (type[ResponseFormat] | None): Pydantic model or built-in type
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
@@ -1714,7 +1714,7 @@ class AsyncOpenAIVecDataFrameAccessor:
         self,
         instructions: str,
         cache: AsyncBatchingMapProxy[str, ResponseFormat],
-        response_format: ResponseFormat = None,
+        response_format: type[ResponseFormat] | None = None,
         max_examples: int = 100,
         **api_kwargs,
     ) -> pd.Series:
@@ -1728,7 +1728,7 @@ class AsyncOpenAIVecDataFrameAccessor:
             instructions (str): System prompt for the LLM.
             cache (AsyncBatchingMapProxy[str, ResponseFormat]): Explicit cache instance for
                 batching and deduplication control.
-            response_format (type[BaseModel] | None): Pydantic model or built-in type
+            response_format (type[ResponseFormat] | None): Pydantic model or built-in type
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
@@ -1756,7 +1756,7 @@ class AsyncOpenAIVecDataFrameAccessor:
     async def parse(
         self,
         instructions: str,
-        response_format: ResponseFormat = None,
+        response_format: type[ResponseFormat] | None = None,
         max_examples: int = 100,
         batch_size: int | None = None,
         max_concurrency: int = 8,
@@ -1771,7 +1771,7 @@ class AsyncOpenAIVecDataFrameAccessor:
 
         Args:
             instructions (str): System prompt for the LLM.
-            response_format (type[BaseModel] | None): Pydantic model or built-in type
+            response_format (type[ResponseFormat] | None): Pydantic model or built-in type
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -274,6 +274,7 @@ class OpenAIVecSeriesAccessor:
     def embeddings_with_cache(
         self,
         cache: BatchingMapProxy[str, np.ndarray],
+        **api_kwargs,
     ) -> pd.Series:
         """Compute OpenAI embeddings for every Series element using a provided cache.
 
@@ -297,6 +298,7 @@ class OpenAIVecSeriesAccessor:
             cache (BatchingMapProxy[str, np.ndarray]): Pre-configured cache
                 instance for managing API call batching and deduplication.
                 Set cache.batch_size=None to enable automatic batch size optimization.
+            **api_kwargs: Additional keyword arguments to pass to the OpenAI API.
 
         Returns:
             pandas.Series: Series whose values are ``np.ndarray`` objects
@@ -306,6 +308,7 @@ class OpenAIVecSeriesAccessor:
             client=CONTAINER.resolve(OpenAI),
             model_name=CONTAINER.resolve(EmbeddingsModelName).value,
             cache=cache,
+            api_kwargs=api_kwargs,
         )
 
         return pd.Series(

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -1283,7 +1283,7 @@ class AsyncOpenAIVecSeriesAccessor:
             cache=AsyncBatchingMapProxy(
                 batch_size=batch_size, max_concurrency=max_concurrency, show_progress=show_progress
             ),
-            api_kwargs=api_kwargs,
+            **api_kwargs,
         )
 
     async def task_with_cache(

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -875,7 +875,7 @@ class OpenAIVecDataFrameAccessor:
             **api_kwargs,
         )
 
-    def infer_schema(self, instructions: str, max_examples: int = 100) -> InferredSchema:
+    def infer_schema(self, instructions: str, max_examples: int = 100, **api_kwargs) -> InferredSchema:
         """Infer a structured data schema from DataFrame rows using AI.
 
         This method analyzes a sample of DataFrame rows to automatically infer
@@ -929,6 +929,7 @@ class OpenAIVecDataFrameAccessor:
         return _df_rows_to_json_series(self._obj).ai.infer_schema(
             instructions=instructions,
             max_examples=max_examples,
+            **api_kwargs,
         )
 
     def extract(self, column: str) -> pd.DataFrame:

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -636,8 +636,6 @@ class OpenAIVecDataFrameAccessor:
         instructions: str,
         cache: BatchingMapProxy[str, ResponseFormat],
         response_format: type[ResponseFormat] = str,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         **api_kwargs,
     ) -> pd.Series:
         """Generate a response for each row after serializing it to JSON using a provided cache.
@@ -671,8 +669,7 @@ class OpenAIVecDataFrameAccessor:
                 Set cache.batch_size=None to enable automatic batch size optimization.
             response_format (type[ResponseFormat], optional): Desired Python type of the
                 responses. Defaults to ``str``.
-            temperature (float | None, optional): Sampling temperature. Defaults to ``0.0``.
-            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, etc.).
 
         Returns:
             pandas.Series: Responses aligned with the DataFrame's original index.
@@ -681,8 +678,6 @@ class OpenAIVecDataFrameAccessor:
             instructions=instructions,
             cache=cache,
             response_format=response_format,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 
@@ -691,8 +686,6 @@ class OpenAIVecDataFrameAccessor:
         instructions: str,
         response_format: type[ResponseFormat] = str,
         batch_size: int | None = None,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         show_progress: bool = False,
         **api_kwargs,
     ) -> pd.Series:
@@ -724,9 +717,8 @@ class OpenAIVecDataFrameAccessor:
             batch_size (int | None, optional): Number of requests sent in one batch.
                 Defaults to ``None`` (automatic batch size optimization
                 based on execution time). Set to a positive integer for fixed batch size.
-            temperature (float | None, optional): Sampling temperature. Defaults to ``0.0``.
-            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
             show_progress (bool, optional): Show progress bar in Jupyter notebooks. Defaults to ``False``.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, etc.).
 
         Returns:
             pandas.Series: Responses aligned with the DataFrame's original index.
@@ -735,8 +727,6 @@ class OpenAIVecDataFrameAccessor:
             instructions=instructions,
             cache=BatchingMapProxy(batch_size=batch_size, show_progress=show_progress),
             response_format=response_format,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 
@@ -829,8 +819,6 @@ class OpenAIVecDataFrameAccessor:
         cache: BatchingMapProxy[str, ResponseFormat],
         response_format: ResponseFormat = None,
         max_examples: int = 100,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         **api_kwargs,
     ) -> pd.Series:
         """Parse DataFrame rows using an LLM with a provided cache.
@@ -847,8 +835,7 @@ class OpenAIVecDataFrameAccessor:
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
-            temperature (float | None): Sampling temperature. Defaults to 0.0.
-            top_p (float): Nucleus sampling parameter. Defaults to 1.0.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, frequency_penalty, etc.).
 
         Additional Keyword Args:
             Arbitrary OpenAI Responses API parameters (e.g. `frequency_penalty`, `presence_penalty`,
@@ -863,8 +850,6 @@ class OpenAIVecDataFrameAccessor:
             cache=cache,
             response_format=response_format,
             max_examples=max_examples,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 
@@ -875,8 +860,6 @@ class OpenAIVecDataFrameAccessor:
         max_examples: int = 100,
         batch_size: int | None = None,
         show_progress: bool = False,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         **api_kwargs,
     ) -> pd.Series:
         """Parse DataFrame rows using an LLM with optional schema inference.
@@ -895,8 +878,7 @@ class OpenAIVecDataFrameAccessor:
                 Defaults to None (automatic optimization).
             show_progress (bool): Whether to display a progress bar during processing.
                 Defaults to False.
-            temperature (float | None): Sampling temperature. Defaults to 0.0.
-            top_p (float): Nucleus sampling parameter. Defaults to 1.0.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, frequency_penalty, etc.).
 
         Returns:
             pandas.Series: Series with parsed structured data as instances of
@@ -907,8 +889,6 @@ class OpenAIVecDataFrameAccessor:
             cache=BatchingMapProxy(batch_size=batch_size, show_progress=show_progress),
             response_format=response_format,
             max_examples=max_examples,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 
@@ -1474,8 +1454,6 @@ class AsyncOpenAIVecSeriesAccessor:
         cache: AsyncBatchingMapProxy[str, ResponseFormat],
         response_format: ResponseFormat = None,
         max_examples: int = 100,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         **api_kwargs,
     ) -> pd.Series:
         """Parse Series values using an LLM with a provided cache (asynchronously).
@@ -1491,8 +1469,7 @@ class AsyncOpenAIVecSeriesAccessor:
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
-            temperature (float | None): Sampling temperature. Defaults to 0.0.
-            top_p (float): Nucleus sampling parameter. Defaults to 1.0.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, frequency_penalty, etc.).
 
         Additional Keyword Args:
             Arbitrary OpenAI Responses API parameters (e.g. `frequency_penalty`, `presence_penalty`,
@@ -1514,8 +1491,6 @@ class AsyncOpenAIVecSeriesAccessor:
             instructions=schema.inference_prompt if schema else instructions,
             cache=cache,
             response_format=response_format or schema.model,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 
@@ -1527,8 +1502,6 @@ class AsyncOpenAIVecSeriesAccessor:
         batch_size: int | None = None,
         max_concurrency: int = 8,
         show_progress: bool = False,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         **api_kwargs,
     ) -> pd.Series:
         """Parse Series values using an LLM with optional schema inference (asynchronously).
@@ -1547,8 +1520,7 @@ class AsyncOpenAIVecSeriesAccessor:
             max_concurrency (int): Maximum number of concurrent requests. Defaults to 8.
             show_progress (bool): Whether to display a progress bar during processing.
                 Defaults to False.
-            temperature (float | None): Sampling temperature. Defaults to 0.0.
-            top_p (float): Nucleus sampling parameter. Defaults to 1.0.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, frequency_penalty, etc.).
 
         Returns:
             pandas.Series: Series with parsed structured data as instances of
@@ -1564,8 +1536,6 @@ class AsyncOpenAIVecSeriesAccessor:
             ),
             response_format=response_format,
             max_examples=max_examples,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 
@@ -1582,8 +1552,6 @@ class AsyncOpenAIVecDataFrameAccessor:
         instructions: str,
         cache: AsyncBatchingMapProxy[str, ResponseFormat],
         response_format: type[ResponseFormat] = str,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         **api_kwargs,
     ) -> pd.Series:
         """Generate a response for each row after serializing it to JSON using a provided cache (asynchronously).
@@ -1619,8 +1587,7 @@ class AsyncOpenAIVecDataFrameAccessor:
                 Set cache.batch_size=None to enable automatic batch size optimization.
             response_format (type[ResponseFormat], optional): Desired Python type of the
                 responses. Defaults to ``str``.
-            temperature (float | None, optional): Sampling temperature. Defaults to ``0.0``.
-            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, etc.).
 
         Returns:
             pandas.Series: Responses aligned with the DataFrame's original index.
@@ -1633,8 +1600,6 @@ class AsyncOpenAIVecDataFrameAccessor:
             instructions=instructions,
             cache=cache,
             response_format=response_format,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 
@@ -1643,8 +1608,6 @@ class AsyncOpenAIVecDataFrameAccessor:
         instructions: str,
         response_format: type[ResponseFormat] = str,
         batch_size: int | None = None,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         max_concurrency: int = 8,
         show_progress: bool = False,
         **api_kwargs,
@@ -1678,8 +1641,7 @@ class AsyncOpenAIVecDataFrameAccessor:
             batch_size (int | None, optional): Number of requests sent in one batch.
                 Defaults to ``None`` (automatic batch size optimization
                 based on execution time). Set to a positive integer for fixed batch size.
-            temperature (float | None, optional): Sampling temperature. Defaults to ``0.0``.
-            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, etc.).
             max_concurrency (int, optional): Maximum number of concurrent
                 requests. Defaults to ``8``.
             show_progress (bool, optional): Show progress bar in Jupyter notebooks. Defaults to ``False``.
@@ -1801,8 +1763,6 @@ class AsyncOpenAIVecDataFrameAccessor:
         cache: AsyncBatchingMapProxy[str, ResponseFormat],
         response_format: ResponseFormat = None,
         max_examples: int = 100,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         **api_kwargs,
     ) -> pd.Series:
         """Parse DataFrame rows using an LLM with a provided cache (asynchronously).
@@ -1819,8 +1779,7 @@ class AsyncOpenAIVecDataFrameAccessor:
                 for structured output. If None, schema is inferred.
             max_examples (int): Maximum number of examples to use for schema inference.
                 Defaults to 100.
-            temperature (float | None): Sampling temperature. Defaults to 0.0.
-            top_p (float): Nucleus sampling parameter. Defaults to 1.0.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, frequency_penalty, etc.).
 
         Additional Keyword Args:
             Arbitrary OpenAI Responses API parameters (e.g. `frequency_penalty`, `presence_penalty`,
@@ -1838,8 +1797,6 @@ class AsyncOpenAIVecDataFrameAccessor:
             cache=cache,
             response_format=response_format,
             max_examples=max_examples,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 
@@ -1851,8 +1808,6 @@ class AsyncOpenAIVecDataFrameAccessor:
         batch_size: int | None = None,
         max_concurrency: int = 8,
         show_progress: bool = False,
-        temperature: float | None = 0.0,
-        top_p: float = 1.0,
         **api_kwargs,
     ) -> pd.Series:
         """Parse DataFrame rows using an LLM with optional schema inference (asynchronously).
@@ -1872,8 +1827,7 @@ class AsyncOpenAIVecDataFrameAccessor:
             max_concurrency (int): Maximum number of concurrent requests. Defaults to 8.
             show_progress (bool): Whether to display a progress bar during processing.
                 Defaults to False.
-            temperature (float | None): Sampling temperature. Defaults to 0.0.
-            top_p (float): Nucleus sampling parameter. Defaults to 1.0.
+            **api_kwargs: Additional OpenAI API parameters (temperature, top_p, frequency_penalty, etc.).
 
         Returns:
             pandas.Series: Series with parsed structured data as instances of
@@ -1889,8 +1843,6 @@ class AsyncOpenAIVecDataFrameAccessor:
             ),
             response_format=response_format,
             max_examples=max_examples,
-            temperature=temperature,
-            top_p=top_p,
             **api_kwargs,
         )
 

--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -625,6 +625,7 @@ def embeddings_udf(
     model_name: str = CONTAINER.resolve(EmbeddingsModelName).value,
     batch_size: int | None = None,
     max_concurrency: int = 8,
+    **api_kwargs,
 ) -> UserDefinedFunction:
     """Create an asynchronous Spark pandas UDF for generating embeddings.
 
@@ -660,6 +661,7 @@ def embeddings_udf(
             Total cluster concurrency = max_concurrency × number_of_executors.
             Higher values increase throughput but may hit OpenAI rate limits.
             Recommended: 4-12 per executor. Defaults to 8.
+        **api_kwargs: Additional OpenAI API parameters (e.g., dimensions for text-embedding-3 models).
 
     Returns:
         UserDefinedFunction: A Spark pandas UDF configured to generate embeddings asynchronously
@@ -686,7 +688,7 @@ def embeddings_udf(
 
         try:
             for part in col:
-                embeddings: pd.Series = asyncio.run(part.aio.embeddings_with_cache(cache=cache))
+                embeddings: pd.Series = asyncio.run(part.aio.embeddings_with_cache(cache=cache, **api_kwargs))
                 yield embeddings.map(lambda x: x.tolist())
         finally:
             asyncio.run(cache.clear())

--- a/src/openaivec/task/__init__.py
+++ b/src/openaivec/task/__init__.py
@@ -117,7 +117,7 @@ All tasks are built using the `PreparedTask` dataclass:
 @dataclass(frozen=True)
 class PreparedTask:
     instructions: str           # Detailed prompt for the LLM
-    response_format: Type[ResponseFormat]    # Pydantic model or str for structured/plain output
+    response_format: type[ResponseFormat]    # Pydantic model or str for structured/plain output
     temperature: float = 0.0    # Sampling temperature
     top_p: float = 1.0         # Nucleus sampling parameter
 ```

--- a/src/openaivec/task/customer_support/customer_sentiment.py
+++ b/src/openaivec/task/customer_support/customer_sentiment.py
@@ -95,15 +95,12 @@ class CustomerSentiment(BaseModel):
     )
 
 
-def customer_sentiment(
-    business_context: str = "general customer support", temperature: float = 0.0, top_p: float = 1.0
-) -> PreparedTask:
+def customer_sentiment(business_context: str = "general customer support", **api_kwargs) -> PreparedTask:
     """Create a configurable customer sentiment analysis task.
 
     Args:
         business_context (str): Business context for sentiment analysis.
-        temperature (float): Sampling temperature (0.0-1.0).
-        top_p (float): Nucleus sampling parameter (0.0-1.0).
+        **api_kwargs: Additional OpenAI API parameters (temperature, top_p, etc.).
 
     Returns:
         PreparedTask configured for customer sentiment analysis.
@@ -169,10 +166,8 @@ values like "positive" for sentiment.
 
 Provide comprehensive sentiment analysis with business context and recommended response strategy."""
 
-    return PreparedTask(
-        instructions=instructions, response_format=CustomerSentiment, temperature=temperature, top_p=top_p
-    )
+    return PreparedTask(instructions=instructions, response_format=CustomerSentiment, api_kwargs=api_kwargs)
 
 
 # Backward compatibility - default configuration
-CUSTOMER_SENTIMENT = customer_sentiment()
+CUSTOMER_SENTIMENT = customer_sentiment(temperature=0.0, top_p=1.0)

--- a/src/openaivec/task/customer_support/inquiry_classification.py
+++ b/src/openaivec/task/customer_support/inquiry_classification.py
@@ -119,8 +119,7 @@ def inquiry_classification(
     priority_rules: Dict[str, str] | None = None,
     business_context: str = "general customer support",
     custom_keywords: Dict[str, list[str]] | None = None,
-    temperature: float = 0.0,
-    top_p: float = 1.0,
+    **api_kwargs,
 ) -> PreparedTask:
     """Create a configurable inquiry classification task.
 
@@ -133,8 +132,8 @@ def inquiry_classification(
             Default uses standard priority indicators.
         business_context (str): Description of the business context to help with classification.
         custom_keywords (dict[str, list[str]] | None): Dictionary mapping categories to relevant keywords.
-        temperature (float): Sampling temperature (0.0-1.0).
-        top_p (float): Nucleus sampling parameter (0.0-1.0).
+        **api_kwargs: Additional keyword arguments to pass to the OpenAI API,
+            such as temperature, top_p, etc.
 
     Returns:
         PreparedTask configured for inquiry classification.
@@ -254,10 +253,8 @@ language where appropriate, but priority must use English values like "high".
 
 Provide accurate classification with detailed reasoning."""
 
-    return PreparedTask(
-        instructions=instructions, response_format=InquiryClassification, temperature=temperature, top_p=top_p
-    )
+    return PreparedTask(instructions=instructions, response_format=InquiryClassification, api_kwargs=api_kwargs)
 
 
 # Backward compatibility - default configuration
-INQUIRY_CLASSIFICATION = inquiry_classification()
+INQUIRY_CLASSIFICATION = inquiry_classification(temperature=0.0, top_p=1.0)

--- a/src/openaivec/task/customer_support/inquiry_summary.py
+++ b/src/openaivec/task/customer_support/inquiry_summary.py
@@ -87,16 +87,15 @@ class InquirySummary(BaseModel):
 def inquiry_summary(
     summary_length: str = "concise",
     business_context: str = "general customer support",
-    temperature: float = 0.0,
-    top_p: float = 1.0,
+    **api_kwargs,
 ) -> PreparedTask:
     """Create a configurable inquiry summary task.
 
     Args:
         summary_length (str): Length of summary (concise, detailed, bullet_points).
         business_context (str): Business context for summary.
-        temperature (float): Sampling temperature (0.0-1.0).
-        top_p (float): Nucleus sampling parameter (0.0-1.0).
+        **api_kwargs: Additional keyword arguments to pass to the OpenAI API,
+            such as temperature, top_p, etc.
 
     Returns:
         PreparedTask configured for inquiry summarization.
@@ -163,8 +162,8 @@ input is in German, provide all summary content in German, but use English value
 
 Provide accurate, actionable summary that enables efficient support resolution."""
 
-    return PreparedTask(instructions=instructions, response_format=InquirySummary, temperature=temperature, top_p=top_p)
+    return PreparedTask(instructions=instructions, response_format=InquirySummary, api_kwargs=api_kwargs)
 
 
 # Backward compatibility - default configuration
-INQUIRY_SUMMARY = inquiry_summary()
+INQUIRY_SUMMARY = inquiry_summary(temperature=0.0, top_p=1.0)

--- a/src/openaivec/task/customer_support/intent_analysis.py
+++ b/src/openaivec/task/customer_support/intent_analysis.py
@@ -100,15 +100,13 @@ class IntentAnalysis(BaseModel):
     )
 
 
-def intent_analysis(
-    business_context: str = "general customer support", temperature: float = 0.0, top_p: float = 1.0
-) -> PreparedTask:
+def intent_analysis(business_context: str = "general customer support", **api_kwargs) -> PreparedTask:
     """Create a configurable intent analysis task.
 
     Args:
         business_context (str): Business context for intent analysis.
-        temperature (float): Sampling temperature (0.0-1.0).
-        top_p (float): Nucleus sampling parameter (0.0-1.0).
+        **api_kwargs: Additional keyword arguments to pass to the OpenAI API,
+            such as temperature, top_p, etc.
 
     Returns:
         PreparedTask configured for intent analysis.
@@ -171,8 +169,8 @@ next_steps, and reasoning in Japanese, but use English values like "get_help" fo
 
 Provide comprehensive intent analysis with actionable recommendations."""
 
-    return PreparedTask(instructions=instructions, response_format=IntentAnalysis, temperature=temperature, top_p=top_p)
+    return PreparedTask(instructions=instructions, response_format=IntentAnalysis, api_kwargs=api_kwargs)
 
 
 # Backward compatibility - default configuration
-INTENT_ANALYSIS = intent_analysis()
+INTENT_ANALYSIS = intent_analysis(temperature=0.0, top_p=1.0)

--- a/src/openaivec/task/customer_support/response_suggestion.py
+++ b/src/openaivec/task/customer_support/response_suggestion.py
@@ -92,8 +92,7 @@ def response_suggestion(
     response_style: str = "professional",
     company_name: str = "our company",
     business_context: str = "general customer support",
-    temperature: float = 0.0,
-    top_p: float = 1.0,
+    **api_kwargs,
 ) -> PreparedTask:
     """Create a configurable response suggestion task.
 
@@ -101,8 +100,8 @@ def response_suggestion(
         response_style (str): Style of response (professional, friendly, empathetic, formal).
         company_name (str): Name of the company for personalization.
         business_context (str): Business context for responses.
-        temperature (float): Sampling temperature (0.0-1.0).
-        top_p (float): Nucleus sampling parameter (0.0-1.0).
+        **api_kwargs: Additional keyword arguments to pass to the OpenAI API,
+            such as temperature, top_p, etc.
 
     Returns:
         PreparedTask configured for response suggestions.
@@ -190,10 +189,8 @@ but use English values like "empathetic" for tone.
 Generate helpful, professional response that moves toward resolution while maintaining
 positive customer relationship."""
 
-    return PreparedTask(
-        instructions=instructions, response_format=ResponseSuggestion, temperature=temperature, top_p=top_p
-    )
+    return PreparedTask(instructions=instructions, response_format=ResponseSuggestion, api_kwargs=api_kwargs)
 
 
 # Backward compatibility - default configuration
-RESPONSE_SUGGESTION = response_suggestion()
+RESPONSE_SUGGESTION = response_suggestion(temperature=0.0, top_p=1.0)

--- a/src/openaivec/task/customer_support/urgency_analysis.py
+++ b/src/openaivec/task/customer_support/urgency_analysis.py
@@ -135,8 +135,7 @@ def urgency_analysis(
     business_context: str = "general customer support",
     business_hours: str = "24/7 support",
     sla_rules: Dict[str, str] | None = None,
-    temperature: float = 0.0,
-    top_p: float = 1.0,
+    **api_kwargs,
 ) -> PreparedTask:
     """Create a configurable urgency analysis task.
 
@@ -149,8 +148,8 @@ def urgency_analysis(
         business_context (str): Description of the business context.
         business_hours (str): Description of business hours for response time calculation.
         sla_rules (dict[str, str] | None): Dictionary mapping customer tiers to SLA requirements.
-        temperature (float): Sampling temperature (0.0-1.0).
-        top_p (float): Nucleus sampling parameter (0.0-1.0).
+        **api_kwargs: Additional keyword arguments to pass to the OpenAI API,
+            such as temperature, top_p, etc.
 
     Returns:
         PreparedTask configured for urgency analysis.
@@ -287,10 +286,8 @@ urgency_level.
 
 Provide detailed analysis with clear reasoning for urgency level and response time recommendations."""
 
-    return PreparedTask(
-        instructions=instructions, response_format=UrgencyAnalysis, temperature=temperature, top_p=top_p
-    )
+    return PreparedTask(instructions=instructions, response_format=UrgencyAnalysis, api_kwargs=api_kwargs)
 
 
 # Backward compatibility - default configuration
-URGENCY_ANALYSIS = urgency_analysis()
+URGENCY_ANALYSIS = urgency_analysis(temperature=0.0, top_p=1.0)

--- a/src/openaivec/task/nlp/dependency_parsing.py
+++ b/src/openaivec/task/nlp/dependency_parsing.py
@@ -75,6 +75,5 @@ DEPENDENCY_PARSING = PreparedTask(
     "relations between words, determine the root word, and provide a tree representation of the "
     "syntactic structure.",
     response_format=DependencyParsing,
-    temperature=0.0,
-    top_p=1.0,
+    api_kwargs={"temperature": 0.0, "top_p": 1.0},
 )

--- a/src/openaivec/task/nlp/keyword_extraction.py
+++ b/src/openaivec/task/nlp/keyword_extraction.py
@@ -75,6 +75,5 @@ KEYWORD_EXTRACTION = PreparedTask(
     instructions="Extract important keywords and phrases from the following text. Rank them "
     "by importance, provide frequency counts, identify main topics, and generate a brief summary.",
     response_format=KeywordExtraction,
-    temperature=0.0,
-    top_p=1.0,
+    api_kwargs={"temperature": 0.0, "top_p": 1.0},
 )

--- a/src/openaivec/task/nlp/morphological_analysis.py
+++ b/src/openaivec/task/nlp/morphological_analysis.py
@@ -70,6 +70,5 @@ MORPHOLOGICAL_ANALYSIS = PreparedTask(
     "identify part-of-speech tags, provide lemmatized forms, and extract morphological features "
     "for each token.",
     response_format=MorphologicalAnalysis,
-    temperature=0.0,
-    top_p=1.0,
+    api_kwargs={"temperature": 0.0, "top_p": 1.0},
 )

--- a/src/openaivec/task/nlp/named_entity_recognition.py
+++ b/src/openaivec/task/nlp/named_entity_recognition.py
@@ -78,6 +78,5 @@ NAMED_ENTITY_RECOGNITION = PreparedTask(
     "organizations, locations, dates, money, percentages, and other miscellaneous entities "
     "with their positions and confidence scores.",
     response_format=NamedEntityRecognition,
-    temperature=0.0,
-    top_p=1.0,
+    api_kwargs={"temperature": 0.0, "top_p": 1.0},
 )

--- a/src/openaivec/task/nlp/sentiment_analysis.py
+++ b/src/openaivec/task/nlp/sentiment_analysis.py
@@ -78,6 +78,5 @@ SENTIMENT_ANALYSIS = PreparedTask(
     "English values specified (positive/negative/neutral for sentiment, and "
     "joy/sadness/anger/fear/surprise/disgust for emotions).",
     response_format=SentimentAnalysis,
-    temperature=0.0,
-    top_p=1.0,
+    api_kwargs={"temperature": 0.0, "top_p": 1.0},
 )

--- a/src/openaivec/task/nlp/translation.py
+++ b/src/openaivec/task/nlp/translation.py
@@ -157,5 +157,5 @@ class TranslatedString(BaseModel):
 instructions = "Translate the following text into multiple languages. "
 
 MULTILINGUAL_TRANSLATION = PreparedTask(
-    instructions=instructions, response_format=TranslatedString, temperature=0.0, top_p=1.0
+    instructions=instructions, response_format=TranslatedString, api_kwargs={"temperature": 0.0, "top_p": 1.0}
 )

--- a/src/openaivec/task/table/fillna.py
+++ b/src/openaivec/task/table/fillna.py
@@ -125,7 +125,7 @@ class FillNaResponse(BaseModel):
     )
 
 
-def fillna(df: pd.DataFrame, target_column_name: str, max_examples: int = 500) -> PreparedTask:
+def fillna(df: pd.DataFrame, target_column_name: str, max_examples: int = 500, **api_kwargs) -> PreparedTask:
     """Create a prepared task for filling missing values in a DataFrame column.
 
     Analyzes the provided DataFrame to understand data patterns and creates
@@ -141,12 +141,14 @@ def fillna(df: pd.DataFrame, target_column_name: str, max_examples: int = 500) -
         max_examples (int): Maximum number of example rows to use for few-shot
             learning. Defaults to 500. Higher values provide more context
             but increase token usage and processing time.
+        **api_kwargs: Additional keyword arguments to pass to the OpenAI API,
+            such as temperature, top_p, etc.
 
     Returns:
         PreparedTask configured for missing value imputation with:
         - Instructions based on DataFrame patterns
         - FillNaResponse format for structured output
-        - Temperature=0.0 and top_p=1.0 for deterministic results
+        - Default deterministic settings (temperature=0.0, top_p=1.0)
 
     Raises:
         ValueError: If target_column_name doesn't exist in DataFrame,
@@ -180,4 +182,7 @@ def fillna(df: pd.DataFrame, target_column_name: str, max_examples: int = 500) -
     if df[target_column_name].notna().sum() == 0:
         raise ValueError(f"Column '{target_column_name}' contains no non-null values for training examples.")
     instructions = get_instructions(df, target_column_name, max_examples)
-    return PreparedTask(instructions=instructions, response_format=FillNaResponse, temperature=0.0, top_p=1.0)
+    # Set default values for deterministic results if not provided
+    if not api_kwargs:
+        api_kwargs = {"temperature": 0.0, "top_p": 1.0}
+    return PreparedTask(instructions=instructions, response_format=FillNaResponse, api_kwargs=api_kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,8 +36,10 @@ def pytest_configure(config):
 def pytest_collection_modifyitems(config, items):
     """Automatically mark async tests."""
     for item in items:
-        # Automatically mark async tests
-        if hasattr(item.function, "__code__") and "async" in item.function.__code__.co_name:
+        # Automatically mark async tests (check if the function is actually async)
+        import asyncio
+
+        if hasattr(item.function, "__code__") and asyncio.iscoroutinefunction(item.function):
             item.add_marker(pytest.mark.asyncio)
 
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -5,7 +5,6 @@ from openaivec._embeddings import AsyncBatchEmbeddings
 
 
 @pytest.mark.requires_api
-@pytest.mark.asyncio
 class TestAsyncBatchEmbeddings:
     @pytest.fixture(autouse=True)
     def setup_client(self, async_openai_client, embeddings_model_name, embedding_dim):
@@ -14,6 +13,7 @@ class TestAsyncBatchEmbeddings:
         self.embedding_dim = embedding_dim
         yield
 
+    @pytest.mark.asyncio
     async def test_create_basic(self):
         """Test basic embedding creation with a small batch size."""
         client = AsyncBatchEmbeddings.of(
@@ -32,6 +32,7 @@ class TestAsyncBatchEmbeddings:
             assert embedding.dtype == np.float32
             assert np.all(np.isfinite(embedding))
 
+    @pytest.mark.asyncio
     async def test_create_empty_input(self):
         """Test embedding creation with an empty input list."""
         client = AsyncBatchEmbeddings.of(
@@ -44,6 +45,7 @@ class TestAsyncBatchEmbeddings:
 
         assert len(response) == 0
 
+    @pytest.mark.asyncio
     async def test_create_with_duplicates(self):
         """Test embedding creation with duplicate inputs. Should return correct embeddings in order."""
         client = AsyncBatchEmbeddings.of(
@@ -67,6 +69,7 @@ class TestAsyncBatchEmbeddings:
         for i, text in enumerate(inputs):
             assert np.allclose(response[i], expected_map[text])
 
+    @pytest.mark.asyncio
     async def test_create_batch_size_larger_than_unique(self):
         """Test when batch_size is larger than the number of unique inputs."""
         client = AsyncBatchEmbeddings.of(
@@ -86,6 +89,7 @@ class TestAsyncBatchEmbeddings:
             assert response[i].shape == (self.embedding_dim,)
             assert response[i].dtype == np.float32
 
+    @pytest.mark.asyncio
     async def test_create_batch_size_one(self):
         """Test embedding creation with batch_size = 1."""
         client = AsyncBatchEmbeddings.of(
@@ -120,6 +124,7 @@ class TestAsyncBatchEmbeddings:
         assert client.cache.max_concurrency == custom_concurrency
 
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
+    @pytest.mark.asyncio
     async def test_create_with_different_batch_sizes(self, batch_size):
         """Test embedding creation with various batch sizes."""
         client = AsyncBatchEmbeddings.of(
@@ -138,6 +143,7 @@ class TestAsyncBatchEmbeddings:
             assert embedding.dtype == np.float32
 
     @pytest.mark.parametrize("concurrency", [2, 4, 8])
+    @pytest.mark.asyncio
     async def test_create_with_different_concurrency(self, concurrency):
         """Test embedding creation with various concurrency settings."""
         client = AsyncBatchEmbeddings.of(

--- a/tests/test_pandas_ext.py
+++ b/tests/test_pandas_ext.py
@@ -85,7 +85,9 @@ class TestPandasExt:
         """Test Series.ai.task method with actual task execution."""
         from openaivec._model import PreparedTask
 
-        task = PreparedTask(instructions="Translate to French", response_format=str, temperature=0.0, top_p=1.0)
+        task = PreparedTask(
+            instructions="Translate to French", response_format=str, api_kwargs={"temperature": 0.0, "top_p": 1.0}
+        )
 
         series = pd.Series(["cat", "dog"])
         results = series.ai.task(task=task, batch_size=2, show_progress=False)
@@ -138,7 +140,9 @@ class TestPandasExt:
         from openaivec._model import PreparedTask
 
         task = PreparedTask(
-            instructions="Extract the animal name from the data", response_format=str, temperature=0.0, top_p=1.0
+            instructions="Extract the animal name from the data",
+            response_format=str,
+            api_kwargs={"temperature": 0.0, "top_p": 1.0},
         )
 
         df = pd.DataFrame([{"animal": "cat", "legs": 4}, {"animal": "dog", "legs": 4}])
@@ -232,8 +236,7 @@ class TestPandasExt:
             task = PreparedTask(
                 instructions="Classify sentiment as positive or negative",
                 response_format=str,
-                temperature=0.0,
-                top_p=1.0,
+                api_kwargs={"temperature": 0.0, "top_p": 1.0},
             )
 
             series = pd.Series(["I love this!", "This is terrible"])
@@ -284,7 +287,9 @@ class TestPandasExt:
         from openaivec._model import PreparedTask
 
         async def run_test():
-            task = PreparedTask(instructions="Describe the animal", response_format=str, temperature=0.0, top_p=1.0)
+            task = PreparedTask(
+                instructions="Describe the animal", response_format=str, api_kwargs={"temperature": 0.0, "top_p": 1.0}
+            )
 
             df = pd.DataFrame([{"name": "fluffy", "type": "cat"}, {"name": "buddy", "type": "dog"}])
 
@@ -622,8 +627,8 @@ class TestPandasExt:
         task = fillna(df_with_missing, "name")
 
         assert task is not None
-        assert task.temperature == 0.0
-        assert task.top_p == 1.0
+        assert task.api_kwargs.get("temperature") == 0.0
+        assert task.api_kwargs.get("top_p") == 1.0
 
     def test_fillna_task_validation(self):
         """Test fillna validation with various edge cases."""
@@ -824,7 +829,7 @@ class TestPandasExt:
         aio_responses_params = list(inspect.signature(series.aio.responses).parameters.keys())
 
         # Common parameters should be in same order (excluding max_concurrency which is async-only)
-        common_params = ["instructions", "response_format", "batch_size", "temperature", "top_p", "show_progress"]
+        common_params = ["instructions", "response_format", "batch_size", "show_progress"]
 
         # Check sync version has these in order
         sync_filtered = [p for p in responses_params if p in common_params]

--- a/tests/test_pandas_ext.py
+++ b/tests/test_pandas_ext.py
@@ -729,7 +729,7 @@ class TestPandasExt:
         series = pd.Series(["Good product", "Bad experience"])
         cache = BatchingMapProxy(batch_size=2)
 
-        results = series.ai.parse_with_cache(instructions="Extract sentiment", cache=cache, show_progress=False)
+        results = series.ai.parse_with_cache(instructions="Extract sentiment", cache=cache)
 
         assert len(results) == 2
         assert all(isinstance(result, (dict, BaseModel)) for result in results)
@@ -737,7 +737,7 @@ class TestPandasExt:
         # Test DataFrame parse_with_cache
         df = pd.DataFrame([{"review": "Great product", "rating": 5}, {"review": "Poor quality", "rating": 1}])
 
-        df_results = df.ai.parse_with_cache(instructions="Analyze sentiment", cache=cache, show_progress=False)
+        df_results = df.ai.parse_with_cache(instructions="Analyze sentiment", cache=cache)
 
         assert len(df_results) == 2
         assert all(isinstance(result, (dict, BaseModel)) for result in df_results)

--- a/tests/test_pandas_ext.py
+++ b/tests/test_pandas_ext.py
@@ -837,5 +837,5 @@ class TestPandasExt:
 
         # Check async version has these in order (with max_concurrency inserted before show_progress)
         async_filtered = [p for p in aio_responses_params if p in common_params or p == "max_concurrency"]
-        expected_async = common_params[:5] + ["max_concurrency"] + [common_params[5]]
+        expected_async = common_params[:-1] + ["max_concurrency"] + [common_params[-1]]
         assert async_filtered == expected_async

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -78,7 +78,6 @@ class TestVectorizedResponsesOpenAI:
 
 
 @pytest.mark.requires_api
-@pytest.mark.asyncio
 class TestAsyncBatchResponses:
     @pytest.fixture(autouse=True)
     def setup_client(self, async_openai_client):
@@ -86,6 +85,7 @@ class TestAsyncBatchResponses:
         self.model_name = "gpt-4.1-mini"
         yield
 
+    @pytest.mark.asyncio
     async def test_parse_str(self):
         system_message = """
         just repeat the user message
@@ -99,6 +99,7 @@ class TestAsyncBatchResponses:
         response: list[str] = await client.parse(["apple", "orange", "banana", "pineapple"])
         assert response == ["apple", "orange", "banana", "pineapple"]
 
+    @pytest.mark.asyncio
     async def test_parse_structured(self):
         system_message = """
         return the color and taste of given fruit
@@ -137,6 +138,7 @@ class TestAsyncBatchResponses:
             assert isinstance(item.taste, str)
             assert len(item.taste) > 0
 
+    @pytest.mark.asyncio
     async def test_parse_structured_empty_input(self):
         system_message = """
         return the color and taste of given fruit
@@ -157,6 +159,7 @@ class TestAsyncBatchResponses:
         response: list[Fruit] = await client.parse([])
         assert response == []
 
+    @pytest.mark.asyncio
     async def test_parse_structured_batch_size(self):
         system_message = """
         return the color and taste of given fruit

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -109,8 +109,7 @@ class TestSparkUDFs:
         simple_task = PreparedTask(
             instructions="Repeat the input text twice, separated by a space.",
             response_format=str,
-            temperature=0.0,
-            top_p=1.0,
+            api_kwargs={"temperature": 0.0, "top_p": 1.0},
         )
 
         self.spark.udf.register(
@@ -142,8 +141,7 @@ class TestSparkUDFs:
         structured_task = PreparedTask(
             instructions="Analyze the text and return the original text and its length.",
             response_format=SimpleResponse,
-            temperature=0.0,
-            top_p=1.0,
+            api_kwargs={"temperature": 0.0, "top_p": 1.0},
         )
 
         self.spark.udf.register(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -24,19 +24,19 @@ class TestPreparedTask:
 
         assert task.instructions == "Test instruction"
         assert task.response_format == SimpleResponse
-        assert task.temperature == 0.0
-        assert task.top_p == 1.0
+        assert task.api_kwargs == {}
 
     def test_prepared_task_creation_with_custom_parameters(self):
         """Test creating a PreparedTask with custom parameters."""
         task = PreparedTask(
-            instructions="Custom instruction", response_format=SimpleResponse, temperature=0.7, top_p=0.9
+            instructions="Custom instruction",
+            response_format=SimpleResponse,
+            api_kwargs={"temperature": 0.7, "top_p": 0.9},
         )
 
         assert task.instructions == "Custom instruction"
         assert task.response_format == SimpleResponse
-        assert task.temperature == 0.7
-        assert task.top_p == 0.9
+        assert task.api_kwargs == {"temperature": 0.7, "top_p": 0.9}
 
     def test_prepared_task_is_frozen(self):
         """Test that PreparedTask is immutable (frozen)."""
@@ -47,35 +47,35 @@ class TestPreparedTask:
             task.instructions = "Modified instruction"
 
         with pytest.raises(FrozenInstanceError):
-            task.temperature = 0.5
+            task.api_kwargs = {"temperature": 0.5}
 
-    def test_prepared_task_temperature_bounds(self):
-        """Test PreparedTask accepts valid temperature values."""
+    def test_prepared_task_api_kwargs_temperature_bounds(self):
+        """Test PreparedTask accepts valid temperature values in api_kwargs."""
         # Test minimum temperature
-        task_min = PreparedTask(instructions="Test", response_format=SimpleResponse, temperature=0.0)
-        assert task_min.temperature == 0.0
+        task_min = PreparedTask(instructions="Test", response_format=SimpleResponse, api_kwargs={"temperature": 0.0})
+        assert task_min.api_kwargs["temperature"] == 0.0
 
         # Test maximum temperature
-        task_max = PreparedTask(instructions="Test", response_format=SimpleResponse, temperature=1.0)
-        assert task_max.temperature == 1.0
+        task_max = PreparedTask(instructions="Test", response_format=SimpleResponse, api_kwargs={"temperature": 1.0})
+        assert task_max.api_kwargs["temperature"] == 1.0
 
         # Test intermediate value
-        task_mid = PreparedTask(instructions="Test", response_format=SimpleResponse, temperature=0.5)
-        assert task_mid.temperature == 0.5
+        task_mid = PreparedTask(instructions="Test", response_format=SimpleResponse, api_kwargs={"temperature": 0.5})
+        assert task_mid.api_kwargs["temperature"] == 0.5
 
-    def test_prepared_task_top_p_bounds(self):
-        """Test PreparedTask accepts valid top_p values."""
+    def test_prepared_task_api_kwargs_top_p_bounds(self):
+        """Test PreparedTask accepts valid top_p values in api_kwargs."""
         # Test minimum top_p
-        task_min = PreparedTask(instructions="Test", response_format=SimpleResponse, top_p=0.0)
-        assert task_min.top_p == 0.0
+        task_min = PreparedTask(instructions="Test", response_format=SimpleResponse, api_kwargs={"top_p": 0.0})
+        assert task_min.api_kwargs["top_p"] == 0.0
 
         # Test maximum top_p
-        task_max = PreparedTask(instructions="Test", response_format=SimpleResponse, top_p=1.0)
-        assert task_max.top_p == 1.0
+        task_max = PreparedTask(instructions="Test", response_format=SimpleResponse, api_kwargs={"top_p": 1.0})
+        assert task_max.api_kwargs["top_p"] == 1.0
 
         # Test intermediate value
-        task_mid = PreparedTask(instructions="Test", response_format=SimpleResponse, top_p=0.5)
-        assert task_mid.top_p == 0.5
+        task_mid = PreparedTask(instructions="Test", response_format=SimpleResponse, api_kwargs={"top_p": 0.5})
+        assert task_mid.api_kwargs["top_p"] == 0.5
 
     def test_prepared_task_response_format_type(self):
         """Test that response_format must be a Pydantic BaseModel type."""
@@ -101,8 +101,7 @@ class TestMultilingualTranslationTask:
         assert task.instructions is not None
         assert len(task.instructions) > 0
         assert task.response_format == TranslatedString
-        assert task.temperature == 0.0
-        assert task.top_p == 1.0
+        assert task.api_kwargs == {"temperature": 0.0, "top_p": 1.0}
 
     def test_multilingual_translation_task_instructions(self):
         """Test that translation task has appropriate instructions."""


### PR DESCRIPTION
close: #63 

This pull request refactors how OpenAI API parameters (like `temperature`, `top_p`, etc.) are handled throughout the codebase, making API parameter passing more flexible and consistent. Instead of hardcoding these parameters as individual arguments, the changes introduce a generic `api_kwargs` dictionary for passing any supported API options. This affects embeddings, prompt building, and batch response classes, both sync and async. The update also ensures that user-supplied parameters can override defaults cleanly at all relevant call sites.

Key changes include:

**Generalization of API Parameter Handling**

* Replaces explicit parameters (such as `temperature` and `top_p`) with a flexible `api_kwargs` dictionary in the `PreparedTask` dataclass and throughout all batch response and embedding classes, allowing arbitrary OpenAI API parameters to be passed and overridden as needed. [[1]](diffhunk://#diff-7396c059070a8d9851b734bf155fc2886cc03b46dd9770b6236a3ff4dc1a9d17L17-R27) [[2]](diffhunk://#diff-7396c059070a8d9851b734bf155fc2886cc03b46dd9770b6236a3ff4dc1a9d17L58-R54) [[3]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL166-L167) [[4]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL396-L397) [[5]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL179-R202) [[6]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL411-R445) [[7]](diffhunk://#diff-790ed8d16c5b9c4e2f21606c9229ca5b21c3bdaf1564ad601c5442a5b84e9e86L36-R56) [[8]](diffhunk://#diff-790ed8d16c5b9c4e2f21606c9229ca5b21c3bdaf1564ad601c5442a5b84e9e86R65-R94)

* Updates all relevant constructors (`of`, `of_task`) and methods (`create`, `_embed_chunk`, etc.) in `BatchEmbeddings`, `BatchResponses`, and `AsyncBatchResponses` to accept and propagate `**api_kwargs`, storing them for use in API calls and allowing them to be overridden per call. [[1]](diffhunk://#diff-790ed8d16c5b9c4e2f21606c9229ca5b21c3bdaf1564ad601c5442a5b84e9e86L36-R56) [[2]](diffhunk://#diff-790ed8d16c5b9c4e2f21606c9229ca5b21c3bdaf1564ad601c5442a5b84e9e86R65-R94) [[3]](diffhunk://#diff-790ed8d16c5b9c4e2f21606c9229ca5b21c3bdaf1564ad601c5442a5b84e9e86L181-R207) [[4]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL179-R202) [[5]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL225-R229) [[6]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL465-R478)

**Parameter Merging and Override Logic**

* Refactors the logic for merging API parameters: stored `api_kwargs` are applied first, and then per-call overrides can be supplied, with special handling for `temperature` and `top_p` to allow explicit removal (i.e., omitting these parameters if set to `None`). [[1]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL278-R295) [[2]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL297-R306) [[3]](diffhunk://#diff-3e7d01fb2294e841858706f1fedffc9d6ce92c63bcc41d04d45ce1b1e0ecb01aL515-R541)

**Documentation and Usability Improvements**

* Updates docstrings, class attributes, and usage examples to reflect the new approach, making parameterization more discoverable and reducing confusion about which parameters are supported and how to use them. [[1]](diffhunk://#diff-7396c059070a8d9851b734bf155fc2886cc03b46dd9770b6236a3ff4dc1a9d17L17-R27) [[2]](diffhunk://#diff-7396c059070a8d9851b734bf155fc2886cc03b46dd9770b6236a3ff4dc1a9d17L46-R43) [[3]](diffhunk://#diff-4fb9e2236902dc6274a928399ba0233255294459d5208afef0891d733566cbeaL448-R448) [[4]](diffhunk://#diff-4fb9e2236902dc6274a928399ba0233255294459d5208afef0891d733566cbeaL463-R462)

**Prompt and Task API Consistency**

* Refactors prompt builder and batch response APIs to accept `**api_kwargs` for all relevant methods, ensuring consistent parameter passing across prompt improvement and batch generation workflows. [[1]](diffhunk://#diff-4fb9e2236902dc6274a928399ba0233255294459d5208afef0891d733566cbeaL448-R448) [[2]](diffhunk://#diff-4fb9e2236902dc6274a928399ba0233255294459d5208afef0891d733566cbeaL482-R481)

Overall, these changes make the codebase more maintainable, extensible, and user-friendly for anyone needing fine-grained control over OpenAI API calls.