### PR TITLE
Fix/sparkdi

### DIFF
--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -393,8 +393,9 @@ def responses_udf(
         instructions (str): The system prompt or instructions for the model.
         response_format (type[ResponseFormat]): The desired output format. Either `str` for plain text
             or a Pydantic `BaseModel` for structured JSON output. Defaults to `str`.
-        model_name (str): For Azure OpenAI, use your deployment name (e.g., "my-gpt4-deployment").
-            For OpenAI, use the model name (e.g., "gpt-4.1-mini"). Defaults to configured model in DI container.
+        model_name (str | None): For Azure OpenAI, use your deployment name (e.g., "my-gpt4-deployment").
+            For OpenAI, use the model name (e.g., "gpt-4.1-mini"). Defaults to configured model in DI container
+            via ResponsesModelName if not provided.
         batch_size (int | None): Number of rows per async batch request within each partition.
             Larger values reduce API call overhead but increase memory usage.
             Defaults to None (automatic batch size optimization that dynamically
@@ -503,8 +504,9 @@ def task_udf(
     Args:
         task (PreparedTask): A predefined task configuration containing instructions,
             response format, and API parameters.
-        model_name (str): For Azure OpenAI, use your deployment name (e.g., "my-gpt4-deployment").
-            For OpenAI, use the model name (e.g., "gpt-4.1-mini"). Defaults to configured model in DI container.
+        model_name (str | None): For Azure OpenAI, use your deployment name (e.g., "my-gpt4-deployment").
+            For OpenAI, use the model name (e.g., "gpt-4.1-mini"). Defaults to configured model in DI container
+            via ResponsesModelName if not provided.
         batch_size (int | None): Number of rows per async batch request within each partition.
             Larger values reduce API call overhead but increase memory usage.
             Defaults to None (automatic batch size optimization that dynamically
@@ -618,8 +620,9 @@ def parse_udf(
             If provided, `example_table_name` must also be specified.
         max_examples (int): Maximum number of examples to retrieve for schema inference.
             Defaults to 100.
-        model_name (str): For Azure OpenAI, use your deployment name (e.g., "my-gpt4-deployment").
-            For OpenAI, use the model name (e.g., "gpt-4.1-mini"). Defaults to configured model in DI container.
+        model_name (str | None): For Azure OpenAI, use your deployment name (e.g., "my-gpt4-deployment").
+            For OpenAI, use the model name (e.g., "gpt-4.1-mini"). Defaults to configured model in DI container
+            via ResponsesModelName if not provided.
         batch_size (int | None): Number of rows per async batch request within each partition.
             Larger values reduce API call overhead but increase memory usage.
             Defaults to None (automatic batch size optimization that dynamically
@@ -692,9 +695,9 @@ def embeddings_udf(
             sc.environment["AZURE_OPENAI_API_VERSION"] = "preview"
 
     Args:
-        model_name (str): For Azure OpenAI, use your deployment name (e.g., "my-embedding-deployment").
+        model_name (str | None): For Azure OpenAI, use your deployment name (e.g., "my-embedding-deployment").
             For OpenAI, use the model name (e.g., "text-embedding-3-small").
-            Defaults to configured model in DI container.
+            Defaults to configured model in DI container via EmbeddingsModelName if not provided.
         batch_size (int | None): Number of rows per async batch request within each partition.
             Larger values reduce API call overhead but increase memory usage.
             Defaults to None (automatic batch size optimization that dynamically

--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -242,6 +242,50 @@ def setup_azure(
     CONTAINER.clear_singletons()
 
 
+def set_responses_model(model_name: str):
+    """Set the default model name for response generation in the DI container.
+
+    Args:
+        model_name (str): The model name to set as default for responses.
+    """
+    CONTAINER.register(ResponsesModelName, lambda: ResponsesModelName(model_name))
+    CONTAINER.clear_singletons()
+
+
+def get_responses_model() -> str | None:
+    """Get the default model name for response generation from the DI container.
+
+    Returns:
+        str | None: The default model name for responses, or None if not set.
+    """
+    try:
+        return CONTAINER.resolve(ResponsesModelName).value
+    except Exception:
+        return None
+
+
+def set_embeddings_model(model_name: str):
+    """Set the default model name for embeddings in the DI container.
+
+    Args:
+        model_name (str): The model name to set as default for embeddings.
+    """
+    CONTAINER.register(EmbeddingsModelName, lambda: EmbeddingsModelName(model_name))
+    CONTAINER.clear_singletons()
+
+
+def get_embeddings_model() -> str | None:
+    """Get the default model name for embeddings from the DI container.
+
+    Returns:
+        str | None: The default model name for embeddings, or None if not set.
+    """
+    try:
+        return CONTAINER.resolve(EmbeddingsModelName).value
+    except Exception:
+        return None
+
+
 def _python_type_to_spark(python_type):
     origin = get_origin(python_type)
 


### PR DESCRIPTION
This pull request makes the model selection for response generation and embeddings more flexible and explicit in the `src/openaivec/spark.py` module. It introduces utility functions to set and get the default model names in the dependency injection (DI) container and updates UDFs to allow overriding the model name per call, improving clarity and usability. The most important changes are:

**Model Selection Utilities:**

* Added `set_responses_model`, `get_responses_model`, `set_embeddings_model`, and `get_embeddings_model` functions to manage default model names for responses and embeddings in the DI container.

**UDF API Improvements:**

* Updated `responses_udf`, `task_udf`, `parse_udf`, and `embeddings_udf` to accept an optional `model_name` argument. If not provided, the default is fetched from the DI container, allowing per-call overrides and clearer docstrings. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL325-R367) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL354-R398) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR428-R436) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL446-R491) [[5]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL462-R509) [[6]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL553-R599) [[7]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL577-R625) [[8]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL625-R672) [[9]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL651-R700)

* Internal logic in UDFs now consistently uses a local `_model_name` variable that resolves to the provided argument or the DI container default. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR428-R436) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL418-R463) [[3]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR728-R732)

**Code Cleanup:**

* Removed an unnecessary import of `EmbeddingsModelName` within the `setup` function, as it is no longer needed.