### PR TITLE
fix: add FewShotPrompt and schema-related classes to __all__ export

### DIFF
--- a/src/openaivec/__init__.py
+++ b/src/openaivec/__init__.py
@@ -1,13 +1,18 @@
 from ._embeddings import AsyncBatchEmbeddings, BatchEmbeddings
 from ._model import PreparedTask
-from ._prompt import FewShotPromptBuilder
+from ._prompt import FewShotPrompt, FewShotPromptBuilder
 from ._responses import AsyncBatchResponses, BatchResponses
+from ._schema import InferredSchema, SchemaInferenceInput, SchemaInferer
 
 __all__ = [
     "AsyncBatchEmbeddings",
     "AsyncBatchResponses",
     "BatchEmbeddings",
     "BatchResponses",
+    "FewShotPrompt",
     "FewShotPromptBuilder",
+    "InferredSchema",
     "PreparedTask",
+    "SchemaInferenceInput",
+    "SchemaInferer",
 ]


### PR DESCRIPTION
This pull request updates the `src/openaivec/__init__.py` file to expose additional classes and functions in the package's public API. The most important changes are the addition of new imports and their inclusion in the `__all__` list, making them available for users of the package.

New public API exports:

* Added `FewShotPrompt` to the imports and the `__all__` list, making it available for use outside the module.
* Added `InferredSchema`, `SchemaInferenceInput`, and `SchemaInferer` from `._schema` to both the imports and the `__all__` list, exposing schema inference functionality.