### PR TITLE
chore: update link format for benchmark reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ print(sentiment.tolist())
 
 ## Benchmarks
 
-Simple task benchmark from `docs/examples/benchmark.ipynb` (100 numeric strings → integer literals, `Series.aio.responses`, model `gpt-5.1`):
+Simple task benchmark from [benchmark.ipynb](https://github.com/microsoft/openaivec/blob/main/docs/examples/benchmark.ipynb) (100 numeric strings → integer literals, `Series.aio.responses`, model `gpt-5.1`):
 
 | Mode                | Settings                                        | Time (s) |
 | ------------------- | ----------------------------------------------- | -------- |


### PR DESCRIPTION
This pull request updates the benchmark documentation in the `README.md` to improve clarity and usability by linking directly to the relevant notebook.

Documentation improvement:

* Updated the benchmark description in `README.md` to replace the inline code reference with a direct link to the `benchmark.ipynb` notebook on GitHub, making it easier for users to access the example.