### PR TITLE
chore: update Google Analytics property ID in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,7 @@ extra:
     - scalable AI
   analytics:
     provider: google
-    property: G-J7N4M1XMRZ
+    property: G-ZZ7FDHLKYS
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/microsoft/openaivec


### PR DESCRIPTION
This pull request makes a minor update to the Google Analytics configuration in the `mkdocs.yml` file, changing the analytics property ID to a new value. This ensures that analytics data is sent to the correct Google Analytics property.

* Updated the Google Analytics `property` value under `analytics` in `mkdocs.yml` to `G-ZZ7FDHLKYS`.