### PR TITLE
chore: update README and index documentation for clarity and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openaivec
 
-Transform pandas and Spark workflows with AI-powered text processing—batching, caching, and guardrails included.
+Transform pandas and Spark workflows with AI-powered text processing—batching, caching, and guardrails included. Built for OpenAI batch pipelines so you can group prompts, cut API overhead, and keep outputs aligned with your data.
 
 [Contributor guidelines](AGENTS.md)
 
@@ -66,6 +66,7 @@ Batching alone removes most HTTP overhead, and letting batching overlap with con
 ## Why openaivec?
 
 - Drop-in `.ai` and `.aio` accessors keep pandas analysts in familiar tooling.
+- OpenAI batch-optimized: `BatchingMapProxy`/`AsyncBatchingMapProxy` coalesce requests, dedupe prompts, and keep column order stable.
 - Smart batching (`BatchingMapProxy`/`AsyncBatchingMapProxy`) dedupes prompts, preserves order, and releases waiters on failure.
 - Reasoning support mirrors the OpenAI SDK; structured outputs accept Pydantic `response_format`.
 - Built-in caches and retries remove boilerplate; helpers reuse caches across pandas, Spark, and async flows.
@@ -74,7 +75,7 @@ Batching alone removes most HTTP overhead, and letting batching overlap with con
 
 # Overview
 
-Vectorized OpenAI access so you process many inputs per call instead of one-by-one. Batching proxies dedupe inputs, enforce ordered outputs, and unblock waiters even on upstream errors. Cache helpers (`responses_with_cache`, Spark UDF builders) plug into the same layer so expensive prompts are reused across pandas, Spark, and async flows. Reasoning models honor SDK semantics. Requires Python 3.10+.
+Vectorized OpenAI batch processing so you handle many inputs per call instead of one-by-one. Batching proxies dedupe inputs, enforce ordered outputs, and unblock waiters even on upstream errors. Cache helpers (`responses_with_cache`, Spark UDF builders) plug into the same layer so expensive prompts are reused across pandas, Spark, and async flows. Reasoning models honor SDK semantics. Requires Python 3.10+.
 
 ## Core Workflows
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
-title: AI-Powered Data Processing for Pandas & Spark
+title: OpenAI Batch Processing for Pandas & Spark
 ---
 
-# AI-Powered Data Processing for Pandas & Spark
+# OpenAI Batch Processing for Pandas & Spark
 
-Welcome to **openaivec** - Transform your data analysis with OpenAI's language models! This library enables seamless integration of AI text processing, sentiment analysis, NLP tasks, and embeddings into your [**Pandas**](https://pandas.pydata.org/) DataFrames and [**Apache Spark**](https://spark.apache.org/) workflows for scalable data insights.
+Welcome to **openaivec** - Transform your data analysis with OpenAI's language models and batch-first pipelines! This library enables seamless integration of AI text processing, sentiment analysis, NLP tasks, and embeddings into your [**Pandas**](https://pandas.pydata.org/) DataFrames and [**Apache Spark**](https://spark.apache.org/) workflows for scalable data insights, while automatically handling OpenAI batch orchestration.
 
 ## 🚀 Quick Start Example
 
@@ -45,6 +45,7 @@ Perfect for **data scientists**, **analysts**, and **ML engineers** who want to 
 
 - **🚀 Vectorized Processing**: Handle thousands of records in minutes, not hours
 - **⚡ Asynchronous Interface**: `.aio` accessor with `batch_size` and `max_concurrency` control
+- **📦 OpenAI Batch Friendly**: `BatchingMapProxy` groups prompts, dedupes inputs, and keeps outputs aligned for pandas and Spark
 - **💰 Cost Efficient**: Automatic deduplication significantly reduces API costs
 - **🔗 Seamless Integration**: Works within existing pandas/Spark workflows
 - **📈 Enterprise Scale**: From 100s to millions of records


### PR DESCRIPTION
This pull request updates the documentation to better emphasize openaivec's support for OpenAI batch processing and its batch-first architecture. The changes clarify that batching, deduplication, and output alignment are core features, and highlight the benefits for pandas and Spark users.

Key documentation updates:

**README and Overview Enhancements:**
* Updated the main description in `README.md` to highlight that openaivec is built for OpenAI batch pipelines, enabling prompt grouping, reduced API overhead, and output alignment with data.
* Added explicit mention of OpenAI batch optimization and the role of `BatchingMapProxy`/`AsyncBatchingMapProxy` in coalescing requests, deduping prompts, and maintaining column order.
* Clarified that the library provides vectorized OpenAI batch processing, not just vectorized access, in the overview section.

**Main Documentation Improvements:**
* Changed the documentation title and introduction in `docs/index.md` to focus on OpenAI batch processing for pandas and Spark, and specified that batch orchestration is handled automatically.
* Added a bullet point to the feature list emphasizing that `BatchingMapProxy` groups prompts, dedupes inputs, and keeps outputs aligned for pandas and Spark.