### PR TITLE
fix: remove environment from build job in docs workflow and update pu…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: pypi
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,4 +31,4 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        run: uv publish
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request updates our GitHub Actions workflows for building documentation and publishing to PyPI. The main changes involve removing an unnecessary environment specification and switching to a more standard action for publishing to PyPI.

**Workflow improvements:**

* Removed the `environment: pypi` specification from the `build` job in `.github/workflows/docs.yml` to simplify the workflow configuration.
* Updated the PyPI publishing step in `.github/workflows/publish.yml` to use the official `pypa/gh-action-pypi-publish` action instead of a manual `uv publish` command, improving reliability and maintainability.…blish step in publish workflow