### PR TITLE
chore: update publish workflow to enable artifact signing and adjust …

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -29,6 +29,31 @@ jobs:
 
       - name: Build with uv
         run: uv build
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign artifacts with cosign (OIDC)
+        run: |
+          set -euo pipefail
+          ls -la dist
+          mkdir -p signatures
+          for f in dist/*; do
+            if [ -f "$f" ]; then
+              base="$(basename "$f")"
+              cosign sign-blob --yes \
+                --output-signature "signatures/${base}.sig" \
+                --output-certificate "signatures/${base}.pem" \
+                "$f"
+            fi
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*
+            signatures/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing releases. It adds artifact signing with cosign and ensures that both the built artifacts and their signatures are included in the GitHub Release. Additionally, permissions are updated to allow writing to the repository contents.

**Security and artifact signing:**

* Added steps to install cosign and sign all files in the `dist` directory with OIDC, storing signatures and certificates in a new `signatures` directory.

**Release process and permissions:**

* Updated permissions for the workflow to allow write access to repository contents, which is required for uploading release assets.
* Modified the release step to include both built artifacts and their corresponding signatures in the GitHub Release.…permissions