### PR TITLE
chore: specify file types for GitHub release artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/*
-            signatures/*
+            dist/*.whl
+            dist/*.tar.gz
+            signatures/*.sig
+            signatures/*.pem
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request updates the release workflow to improve the specificity and security of the published artifacts. The most important changes are:

Release artifact selection:

* The GitHub release step now uploads only `.whl` and `.tar.gz` files from the `dist` directory, instead of all files, ensuring only relevant package formats are included.

Signature handling:

* The workflow now uploads only `.sig` and `.pem` files from the `signatures` directory, rather than all files, which helps restrict the published signatures to the intended formats.