### PR TITLE
fix: remove unnecessary axis parameter in drop method for cleaner Dat…

### DIFF
--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -1087,7 +1087,7 @@ class OpenAIVecDataFrameAccessor:
             self._obj.pipe(lambda df: df.reset_index(drop=True))
             .pipe(lambda df: df.join(df[column].ai.extract()))
             .pipe(lambda df: df.set_index(self._obj.index))
-            .pipe(lambda df: df.drop(columns=[column], axis=1))
+            .pipe(lambda df: df.drop(columns=[column]))
         )
 
     def fillna(


### PR DESCRIPTION
This pull request makes a minor adjustment to the `extract` method in `src/openaivec/pandas_ext.py` for dropping columns. The change simplifies the call to `drop()` by removing the unnecessary `axis=1` argument, since specifying `columns=[column]` already implies `axis=1`.…aFrame manipulation