### PR TITLE
fix: ignore placeholser

### DIFF
--- a/src/openaivec/_provider.py
+++ b/src/openaivec/_provider.py
@@ -31,7 +31,7 @@ __all__ = []
 CONTAINER = di.Container()
 _DEFAULT_REGISTRATIONS_LOCK = threading.RLock()
 _DEFAULT_REGISTRATIONS_READY = False
-_IGNORE_API_KEY_LIST = ["place_holder_for_fabric_internal"]
+_IGNORE_API_KEYS = frozenset(["place_holder_for_fabric_internal"])
 
 
 def _build_missing_credentials_error(
@@ -125,7 +125,7 @@ def provide_openai_client() -> OpenAI:
     """
     ensure_default_registrations()
     openai_api_key = CONTAINER.resolve(OpenAIAPIKey)
-    if openai_api_key.value and openai_api_key.value not in _IGNORE_API_KEY_LIST:
+    if openai_api_key.value and openai_api_key.value not in _IGNORE_API_KEYS:
         return OpenAI()
 
     azure_api_key = CONTAINER.resolve(AzureOpenAIAPIKey)
@@ -176,7 +176,7 @@ def provide_async_openai_client() -> AsyncOpenAI:
     """
     ensure_default_registrations()
     openai_api_key = CONTAINER.resolve(OpenAIAPIKey)
-    if openai_api_key.value and openai_api_key.value not in _IGNORE_API_KEY_LIST:
+    if openai_api_key.value and openai_api_key.value not in _IGNORE_API_KEYS:
         return AsyncOpenAI()
 
     azure_api_key = CONTAINER.resolve(AzureOpenAIAPIKey)

--- a/src/openaivec/_provider.py
+++ b/src/openaivec/_provider.py
@@ -31,6 +31,7 @@ __all__ = []
 CONTAINER = di.Container()
 _DEFAULT_REGISTRATIONS_LOCK = threading.RLock()
 _DEFAULT_REGISTRATIONS_READY = False
+_IGNORE_API_KEY_LIST = ["place_holder_for_fabric_internal"]
 
 
 def _build_missing_credentials_error(
@@ -124,7 +125,7 @@ def provide_openai_client() -> OpenAI:
     """
     ensure_default_registrations()
     openai_api_key = CONTAINER.resolve(OpenAIAPIKey)
-    if openai_api_key.value:
+    if openai_api_key.value and openai_api_key.value not in _IGNORE_API_KEY_LIST:
         return OpenAI()
 
     azure_api_key = CONTAINER.resolve(AzureOpenAIAPIKey)
@@ -175,7 +176,7 @@ def provide_async_openai_client() -> AsyncOpenAI:
     """
     ensure_default_registrations()
     openai_api_key = CONTAINER.resolve(OpenAIAPIKey)
-    if openai_api_key.value:
+    if openai_api_key.value and openai_api_key.value not in _IGNORE_API_KEY_LIST:
         return AsyncOpenAI()
 
     azure_api_key = CONTAINER.resolve(AzureOpenAIAPIKey)


### PR DESCRIPTION
This pull request updates the logic for providing OpenAI clients to ensure that certain placeholder API keys are ignored and do not trigger client instantiation. The main change is the introduction of an `_IGNORE_API_KEY_LIST` and additional checks to prevent using ignored API keys.

Credential validation improvements:

* Added `_IGNORE_API_KEY_LIST` to `src/openaivec/_provider.py` to specify API keys that should be ignored during client instantiation.
* Updated `provide_openai_client()` and `provide_async_openai_client()` to only instantiate clients if the resolved API key is not in `_IGNORE_API_KEY_LIST`. [[1]](diffhunk://#diff-664a98bccc84414f1f828a32ad7bb49b61dcc2be0c41be57f605039826ecf0ecL127-R128) [[2]](diffhunk://#diff-664a98bccc84414f1f828a32ad7bb49b61dcc2be0c41be57f605039826ecf0ecL178-R179)