### PR TITLE
docs(fabric): document SP + Key Vault auth and fix Foundry token scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,9 +438,23 @@ Inside Fabric notebooks, the recommended way to authenticate against Azure OpenA
 **One-time setup**
 
 1. Create a Service Principal (App Registration) in Microsoft Entra ID and generate a client secret.
-2. Assign the Service Principal a data-plane role on the AI resource (for example, `Cognitive Services OpenAI User` on the Azure OpenAI resource, or `Azure AI User` on the Foundry project).
+2. Assign the Service Principal a data-plane role on the AI resource so it can call inference (see role table below).
 3. Store the client secret in an Azure Key Vault.
 4. Grant the **Fabric Workspace identity** the `Key Vault Secrets User` role on that Key Vault. The workspace identity — not the user — is what authenticates from the notebook to Key Vault.
+
+**Required Azure roles**
+
+| Identity | Role | Scope | Purpose |
+|---|---|---|---|
+| Service Principal | [`Cognitive Services OpenAI User`](https://learn.microsoft.com/azure/ai-foundry/openai/how-to/role-based-access-control#cognitive-services-openai-user) | Azure OpenAI resource (or its resource group / subscription) | Call `responses` / `embeddings` against an Azure OpenAI endpoint. |
+| Service Principal | [`Azure AI User`](https://learn.microsoft.com/azure/ai-foundry/concepts/rbac-azure-ai-foundry#azure-ai-user) | Azure AI Foundry project (Cognitive Services / AI Services account) | Call inference through a Foundry project endpoint (`/api/projects/<name>/openai/v1/`). |
+| Fabric Workspace identity | [`Key Vault Secrets User`](https://learn.microsoft.com/azure/key-vault/general/rbac-guide#azure-built-in-roles-for-key-vault-data-plane-operations) | The Key Vault holding the SP secret | Allow `notebookutils.credentials.getSecret` to read the secret at runtime. |
+
+Notes:
+
+- Use **`Cognitive Services OpenAI User`** when you talk directly to an Azure OpenAI resource endpoint (`https://<resource>.openai.azure.com/` or `https://<resource>.services.ai.azure.com/openai/v1/`). It grants the minimum needed to invoke deployments; do **not** assign `Cognitive Services OpenAI Contributor` unless the SP must also manage deployments.
+- Use **`Azure AI User`** when you call a Foundry project endpoint (Option B below). Foundry data-plane RBAC is documented at [Role-based access control for Azure AI Foundry](https://learn.microsoft.com/azure/ai-foundry/concepts/rbac-azure-ai-foundry).
+- The Key Vault must use [Azure RBAC permission model](https://learn.microsoft.com/azure/key-vault/general/rbac-guide) (not legacy access policies) for `Key Vault Secrets User` to take effect.
 
 References: [NotebookUtils credentials](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials), [Fabric Spark security: accessing Key Vault](https://learn.microsoft.com/fabric/data-engineering/spark-best-practices-security#accessing-azure-key-vault-akv-from-notebook), [Azure OpenAI with Microsoft Entra ID](https://learn.microsoft.com/azure/ai-foundry/openai/how-to/managed-identity).
 

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ credential = ClientSecretCredential(
 )
 token_provider = get_bearer_token_provider(
     credential,
-    "https://cognitiveservices.azure.com/.default",
+    "https://ai.azure.com/.default",
 )
 
 openaivec.set_client(OpenAI(
@@ -516,7 +516,7 @@ openaivec.set_client(OpenAI(
 openaivec.set_responses_model("<your-deployment-or-model>")
 ```
 
-The `https://cognitiveservices.azure.com/.default` scope is the [documented audience for Azure OpenAI / Azure AI Foundry inference](https://learn.microsoft.com/azure/ai-foundry/openai/reference#authentication).
+The `https://ai.azure.com/.default` scope is the [documented audience for Microsoft Foundry Models endpoints](https://learn.microsoft.com/azure/foundry/foundry-models/concepts/endpoints#keyless-authentication) (`*.services.ai.azure.com`). Older classic Azure OpenAI references may show `https://cognitiveservices.azure.com/.default`; for the Foundry endpoint shape recommended above, use `ai.azure.com`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,79 @@ prompt = (
 
 [Microsoft Fabric](https://www.microsoft.com/en-us/microsoft-fabric/) is a unified, cloud-based analytics platform. Add `openaivec` from PyPI in your Fabric environment, select it in your notebook, and use `openaivec.spark_ext` like standard Spark.
 
+### Recommended authentication: Service Principal + Key Vault
+
+Inside Fabric notebooks, the recommended way to authenticate against Azure OpenAI / Azure AI Foundry is to keep a Service Principal client secret in Azure Key Vault and retrieve it through [`notebookutils.credentials.getSecret`](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials#get-secret). Never hard-code secrets in notebooks.
+
+**One-time setup**
+
+1. Create a Service Principal (App Registration) in Microsoft Entra ID and generate a client secret.
+2. Assign the Service Principal a data-plane role on the AI resource (for example, `Cognitive Services OpenAI User` on the Azure OpenAI resource, or `Azure AI User` on the Foundry project).
+3. Store the client secret in an Azure Key Vault.
+4. Grant the **Fabric Workspace identity** the `Key Vault Secrets User` role on that Key Vault. The workspace identity — not the user — is what authenticates from the notebook to Key Vault.
+
+References: [NotebookUtils credentials](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials), [Fabric Spark security: accessing Key Vault](https://learn.microsoft.com/fabric/data-engineering/spark-best-practices-security#accessing-azure-key-vault-akv-from-notebook), [Azure OpenAI with Microsoft Entra ID](https://learn.microsoft.com/azure/ai-foundry/openai/how-to/managed-identity).
+
+#### Option A — env-var driven (recommended)
+
+`openaivec` detects Fabric and pulls the client secret from Key Vault automatically when these four env vars are set, then builds the bearer-token provider for you:
+
+```python
+import os
+
+os.environ["AZURE_TENANT_ID"]          = "<your-tenant-id>"          # Service Principal tenant
+os.environ["AZURE_CLIENT_ID"]          = "<your-client-id>"          # Service Principal client ID
+os.environ["KEY_VAULT_URL"]            = "https://<your-keyvault>.vault.azure.net/"
+os.environ["KEY_VAULT_SECRET_NAME"]    = "<your-secret-name>"        # SP client secret in KV
+
+os.environ["AZURE_OPENAI_BASE_URL"]    = "https://<your-resource>.services.ai.azure.com/openai/v1/"
+os.environ["AZURE_OPENAI_API_VERSION"] = "v1"
+
+import pandas as pd
+from openaivec import pandas_ext  # noqa: F401  registers the .ai accessor
+
+pd.Series(["apple", "banana"]).ai.responses("Translate to French.")
+```
+
+Do **not** set `AZURE_OPENAI_API_KEY`; leaving it unset is what triggers the Entra ID code path.
+
+#### Option B — bring your own `OpenAI` client (Foundry project endpoint)
+
+For Azure AI Foundry **project endpoints** (`/api/projects/<name>/openai/v1/`) you can build the `OpenAI` client manually and hand it to `openaivec`:
+
+```python
+import notebookutils
+from azure.identity import ClientSecretCredential, get_bearer_token_provider
+from openai import OpenAI
+
+import openaivec
+
+TENANT_ID = "<your-tenant-id>"           # Service Principal tenant
+CLIENT_ID = "<your-client-id>"           # Service Principal client ID
+KV_URI    = "https://<your-keyvault>.vault.azure.net/"
+SECRET    = "<your-secret-name>"         # SP client secret in KV
+
+client_secret = notebookutils.credentials.getSecret(KV_URI, SECRET)
+
+credential = ClientSecretCredential(
+    tenant_id=TENANT_ID,
+    client_id=CLIENT_ID,
+    client_secret=client_secret,
+)
+token_provider = get_bearer_token_provider(
+    credential,
+    "https://cognitiveservices.azure.com/.default",
+)
+
+openaivec.set_client(OpenAI(
+    base_url="https://<your-resource>.services.ai.azure.com/api/projects/<your-project>/openai/v1/",
+    api_key=token_provider,
+))
+openaivec.set_responses_model("<your-deployment-or-model>")
+```
+
+The `https://cognitiveservices.azure.com/.default` scope is the [documented audience for Azure OpenAI / Azure AI Foundry inference](https://learn.microsoft.com/azure/ai-foundry/openai/reference#authentication).
+
 ## Contributing
 
 We welcome contributions! Please:

--- a/src/openaivec/_provider.py
+++ b/src/openaivec/_provider.py
@@ -240,9 +240,7 @@ def _provide_bearer_token_provider() -> BearerTokenProvider:
     else:
         credential = DefaultAzureCredential()
 
-    return BearerTokenProvider(
-        value=get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default")
-    )
+    return BearerTokenProvider(value=get_bearer_token_provider(credential, "https://ai.azure.com/.default"))
 
 
 def _register_default_providers() -> None:


### PR DESCRIPTION
## Summary

Updates Microsoft Fabric authentication documentation and fixes the bearer-token scope used for Microsoft Foundry Models endpoints.

## Changes

- **README.md**: Expand the "Using with Microsoft Fabric" section with:
  - One-time setup for Service Principal + Azure Key Vault, retrieved via `notebookutils.credentials.getSecret`.
  - Required Azure roles table (`Cognitive Services OpenAI User`, `Azure AI User`, `Key Vault Secrets User`) with links to official RBAC docs.
  - **Option A** — env-var driven flow leveraging openaivec's automatic Fabric detection (\`AZURE_TENANT_ID\` / \`AZURE_CLIENT_ID\` / \`KEY_VAULT_URL\` / \`KEY_VAULT_SECRET_NAME\` + \`AZURE_OPENAI_BASE_URL\`).
  - **Option B** — bring-your-own \`OpenAI\` client for Foundry project endpoints.
- **src/openaivec/_provider.py**: Switch the bearer-token provider scope from \`https://cognitiveservices.azure.com/.default\` to \`https://ai.azure.com/.default\`, per the [official Microsoft Foundry Models endpoints documentation](https://learn.microsoft.com/azure/foundry/foundry-models/concepts/endpoints#keyless-authentication) ("Tokens must be issued with scope \`https://ai.azure.com/.default\`"). The new scope is the documented audience for the \`*.services.ai.azure.com\` endpoint shape that openaivec recommends.

## Verification

- \`uv run ruff check .\` — all checks passed
- \`uv run ruff format --check .\` — 75 files already formatted
- \`uv run pytest -q -m "not slow and not requires_api"\` — 378 passed