### PR TITLE
fix(provider): wrap sync bearer token provider as async for AsyncAzureOpenAI

### DIFF
--- a/src/openaivec/_provider.py
+++ b/src/openaivec/_provider.py
@@ -196,9 +196,14 @@ def provide_async_openai_client() -> AsyncOpenAI:
                 api_version=azure_api_version.value,
             )
 
+        sync_token_provider = CONTAINER.resolve(BearerTokenProvider).value
+
+        async def _async_token_provider() -> str:
+            return sync_token_provider()
+
         return AsyncAzureOpenAI(
             api_key=_ENTRA_ID_API_KEY_PLACEHOLDER,
-            azure_ad_token_provider=CONTAINER.resolve(BearerTokenProvider).value,
+            azure_ad_token_provider=_async_token_provider,
             base_url=azure_base_url.value,
             api_version=azure_api_version.value,
         )

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -307,6 +307,34 @@ class TestProvideAsyncOpenAIClient:
 
         assert isinstance(client, AsyncOpenAI)
 
+    def test_provide_async_openai_client_entra_id_token_provider_is_awaitable(self):
+        """The Entra ID token provider passed to AsyncAzureOpenAI must be an async callable.
+
+        Regression test for ``TypeError: object str can't be used in 'await' expression``
+        raised by ``AsyncAzureOpenAI._refresh_api_key`` when a synchronous
+        ``azure_ad_token_provider`` is supplied.
+        """
+        import asyncio
+        import inspect
+
+        from openaivec._model import BearerTokenProvider
+        from openaivec._provider import CONTAINER
+
+        self.set_env_and_reset(
+            AZURE_OPENAI_BASE_URL="https://test.services.ai.azure.com/openai/v1/",
+            AZURE_OPENAI_API_VERSION="v1",
+        )
+        CONTAINER.register(BearerTokenProvider, lambda: BearerTokenProvider(value=lambda: "fake-token"))
+
+        client = provide_async_openai_client()
+
+        assert isinstance(client, AsyncAzureOpenAI)
+        token_provider = client._azure_ad_token_provider
+        assert token_provider is not None
+        assert inspect.iscoroutinefunction(token_provider)
+        token = asyncio.run(token_provider())
+        assert token == "fake-token"
+
 
 @pytest.mark.integration
 class TestProviderIntegration:


### PR DESCRIPTION
## Summary

Fixes a runtime error in async paths (e.g. multimodal file upload) when openaivec is configured with Entra ID auth on Azure OpenAI / Foundry endpoints:

\`\`\`
TypeError: object str can't be used in 'await' expression
  at openai/_client.py: _refresh_api_key
  at openaivec/_multimodal.py: _upload  (await self.client.files.create(...))
\`\`\`

## Root cause

\`provide_async_openai_client()\` was passing the sync callable returned by \`azure.identity.get_bearer_token_provider\` directly to \`AsyncAzureOpenAI(azure_ad_token_provider=...)\`. The OpenAI SDK's async client awaits this callable in \`_refresh_api_key\`, but the sync provider returns \`str\` synchronously — so \`await str\` raised \`TypeError\`.

The sync \`AzureOpenAI\` path was unaffected.

## Fix

Wrap the sync token provider in an \`async def\` before passing it to \`AsyncAzureOpenAI\`. Sync clients keep using the sync provider unchanged.

## Verification

- \`uv run pytest tests/test_provider.py -q\` — 60 passed (incl. new regression test that asserts the token provider is a coroutine function and yields the expected value via \`asyncio.run\`).
- \`uv run pytest -q -m \"not slow and not requires_api\"\` — 379 passed.
- \`uv run ruff check .\` / \`uv run ruff format --check .\` — clean.