### PR TITLE
docs(fabric): add Fabric + DuckDB multimodal PDF example

### DIFF
--- a/docs/examples/fabric_duckdb.ipynb
+++ b/docs/examples/fabric_duckdb.ipynb
@@ -1,0 +1,1256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fe01a3ca",
+   "metadata": {},
+   "source": [
+    "# Microsoft Fabric × DuckDB × openaivec — Structured PDF Extraction (Inventory Transfer Slips)\n",
+    "\n",
+    "This notebook is designed to run inside a **Microsoft Fabric Notebook** and builds the following pipeline:\n",
+    "\n",
+    "1. Read inventory transfer slip PDFs from `Files/transfer/*.pdf` of a Fabric Lakehouse via [DuckDB](https://duckdb.org/).\n",
+    "2. Use [openaivec](https://github.com/microsoft/openaivec)'s `responses_udf` to parse each PDF into a Pydantic schema with an Azure OpenAI multimodal model.\n",
+    "3. Convert the result to a pandas DataFrame and write it to Delta Lake on OneLake.\n",
+    "\n",
+    "`responses_udf` takes care of batching, deduplication, retry, and structured output (Pydantic `response_format`), so your code is essentially **just SQL + a Pydantic schema**.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "### 1. Fabric / OneLake\n",
+    "\n",
+    "- This notebook is placed in a **Fabric workspace**.\n",
+    "- A **Lakehouse** (e.g. `bronze.Lakehouse`) is created and attached as the default Lakehouse of this notebook.\n",
+    "- Input PDFs are uploaded to `Files/transfer/` of that Lakehouse (accessible from the kernel via the POSIX path `/lakehouse/default/Files/transfer/*.pdf`).\n",
+    "- The Delta write target (e.g. `abfss://<workspace>@onelake.dfs.fabric.microsoft.com/<lakehouse>.Lakehouse/Tables/...`) is writable.\n",
+    "\n",
+    "### 2. Azure OpenAI / AI Foundry\n",
+    "\n",
+    "- An Azure OpenAI or AI Foundry endpoint in **v1 API format**:\n",
+    "  - Example: `https://<your-resource>.services.ai.azure.com/openai/v1/`\n",
+    "  - Foundry project variant: `https://<your-resource>.services.ai.azure.com/api/projects/<project>/openai/v1/`\n",
+    "- A **multimodal-capable deployment** (e.g. a `gpt-4.1-mini` family model) is deployed under that endpoint.\n",
+    "\n",
+    "### 3. Entra ID authentication (Service Principal + Key Vault, accessed via the Fabric Workspace identity)\n",
+    "\n",
+    "Fabric Notebooks do not support `DefaultAzureCredential` directly, so the Service Principal's `clientSecret` is retrieved from Key Vault and a `ClientSecretCredential` is constructed. openaivec's `_provider.py` performs this automatically when `KEY_VAULT_URL` and `KEY_VAULT_SECRET_NAME` are set.\n",
+    "\n",
+    "**Important — Key Vault access uses the Fabric Workspace identity**: under the hood, `notebookutils.credentials.getSecret(...)` calls Key Vault as the **Fabric workspace** (identified by its Workspace ID), **not** as the Service Principal you are about to use against Azure OpenAI, and **not** as the interactive user. You therefore need to grant Key Vault read permission to the workspace itself.\n",
+    "\n",
+    "| Item | Details |\n",
+    "| --- | --- |\n",
+    "| Service Principal (SP) | Create an App Registration; note its `tenantId` and `clientId`. |\n",
+    "| SP role on Azure OpenAI / Foundry | Grant the SP the **`Cognitive Services OpenAI User`** role on the AI resource. |\n",
+    "| Key Vault — store secret | Store the SP's `clientSecret` as a Key Vault secret. |\n",
+    "| Key Vault — RBAC (workspace) | Grant **`Key Vault Secrets User`** to the **Fabric workspace identity** (object id = Fabric Workspace ID). This is the principal that `notebookutils.credentials.getSecret` impersonates. |\n",
+    "| Key Vault access model | Use **Azure RBAC** (not legacy access policies) on the Key Vault so the workspace assignment is honored. |\n",
+    "\n",
+    "> How to find the Fabric Workspace ID: open the workspace in the Fabric portal, click *Workspace settings → About*, and copy the **Workspace ID** (GUID). Assign roles against this object id in Key Vault's *Access control (IAM)*.\n",
+    "\n",
+    "> **Security**: all Tenant ID / Client ID / Key Vault URI / endpoint values in the cells below are **placeholders**. Replace them with your own values and never commit real secrets to a repository.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6290eb36",
+   "metadata": {},
+   "source": [
+    "## 1. Install dependencies\n",
+    "\n",
+    "Uninstall the older `openai` shipped with the Fabric runtime, then install `openaivec` (which pulls in the latest `openai`) and `azure-identity`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e6139d4-e7fb-4836-8ac8-b471afd3e46f",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "_source_": "storage",
+       "execution_finish_time": null,
+       "execution_start_time": "2026-05-28T01:50:11.8323446Z",
+       "normalized_state": "running",
+       "parent_msg_id": "24de85e4-767d-44da-9577-0b7fff749d36",
+       "queued_time": "2026-05-28T01:50:06.3600959Z",
+       "session_id": "c628eabc-e1e8-428b-be36-3a644770d779",
+       "session_start_time": "2026-05-28T01:50:06.3610349Z"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found existing installation: openai 1.109.1\n",
+      "Uninstalling openai-1.109.1:\n",
+      "  Successfully uninstalled openai-1.109.1\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "Collecting openaivec\n",
+      "  Downloading openaivec-2.3.1-py3-none-any.whl.metadata (21 kB)\n",
+      "Requirement already satisfied: aiohttp>=3.9.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openaivec) (3.12.15)\n",
+      "Requirement already satisfied: azure-identity>=1.25.1 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openaivec) (1.25.1)\n",
+      "Requirement already satisfied: duckdb>=1.0.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openaivec) (1.4.4)\n",
+      "Requirement already satisfied: ipywidgets>=8.1.7 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openaivec) (8.1.7)\n",
+      "Collecting openai>=2.0.0 (from openaivec)\n",
+      "  Downloading openai-2.38.0-py3-none-any.whl.metadata (31 kB)\n",
+      "Collecting pandas>=3.0.0 (from openaivec)\n",
+      "  Downloading pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl.metadata (79 kB)\n",
+      "Requirement already satisfied: pyarrow>=19.0.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openaivec) (22.0.0)\n",
+      "Collecting tiktoken>=0.9.0 (from openaivec)\n",
+      "  Downloading tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (6.7 kB)\n",
+      "Requirement already satisfied: tqdm>=4.67.1 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openaivec) (4.67.1)\n",
+      "Requirement already satisfied: aiohappyeyeballs>=2.5.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from aiohttp>=3.9.0->openaivec) (2.6.1)\n",
+      "Requirement already satisfied: aiosignal>=1.4.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from aiohttp>=3.9.0->openaivec) (1.4.0)\n",
+      "Requirement already satisfied: attrs>=17.3.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from aiohttp>=3.9.0->openaivec) (25.4.0)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from aiohttp>=3.9.0->openaivec) (1.8.0)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from aiohttp>=3.9.0->openaivec) (6.7.1)\n",
+      "Requirement already satisfied: propcache>=0.2.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from aiohttp>=3.9.0->openaivec) (0.4.1)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from aiohttp>=3.9.0->openaivec) (1.22.0)\n",
+      "Requirement already satisfied: idna>=2.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from yarl<2.0,>=1.17.0->aiohttp>=3.9.0->openaivec) (3.11)\n",
+      "Requirement already satisfied: typing-extensions>=4.2 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from aiosignal>=1.4.0->aiohttp>=3.9.0->openaivec) (4.15.0)\n",
+      "Requirement already satisfied: azure-core>=1.31.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from azure-identity>=1.25.1->openaivec) (1.36.0)\n",
+      "Requirement already satisfied: cryptography>=2.5 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from azure-identity>=1.25.1->openaivec) (46.0.4)\n",
+      "Requirement already satisfied: msal>=1.30.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from azure-identity>=1.25.1->openaivec) (1.34.0)\n",
+      "Requirement already satisfied: msal-extensions>=1.2.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from azure-identity>=1.25.1->openaivec) (1.3.1)\n",
+      "Requirement already satisfied: requests>=2.21.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from azure-core>=1.31.0->azure-identity>=1.25.1->openaivec) (2.32.5)\n",
+      "Requirement already satisfied: cffi>=2.0.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from cryptography>=2.5->azure-identity>=1.25.1->openaivec) (2.0.0)\n",
+      "Requirement already satisfied: pycparser in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from cffi>=2.0.0->cryptography>=2.5->azure-identity>=1.25.1->openaivec) (2.23)\n",
+      "Requirement already satisfied: comm>=0.1.3 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipywidgets>=8.1.7->openaivec) (0.2.3)\n",
+      "Requirement already satisfied: ipython>=6.1.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipywidgets>=8.1.7->openaivec) (9.7.0)\n",
+      "Requirement already satisfied: traitlets>=4.3.1 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipywidgets>=8.1.7->openaivec) (5.14.3)\n",
+      "Requirement already satisfied: widgetsnbextension~=4.0.14 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipywidgets>=8.1.7->openaivec) (4.0.14)\n",
+      "Requirement already satisfied: jupyterlab_widgets~=3.0.15 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipywidgets>=8.1.7->openaivec) (3.0.16)\n",
+      "Requirement already satisfied: decorator>=4.3.2 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (5.2.1)\n",
+      "Requirement already satisfied: ipython-pygments-lexers>=1.0.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (1.1.1)\n",
+      "Requirement already satisfied: jedi>=0.18.1 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (0.19.2)\n",
+      "Requirement already satisfied: matplotlib-inline>=0.1.5 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (0.2.1)\n",
+      "Requirement already satisfied: pexpect>4.3 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (4.9.0)\n",
+      "Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (3.0.52)\n",
+      "Requirement already satisfied: pygments>=2.11.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (2.19.2)\n",
+      "Requirement already satisfied: stack_data>=0.6.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (0.6.3)\n",
+      "Requirement already satisfied: wcwidth in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (0.2.14)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from jedi>=0.18.1->ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (0.8.5)\n",
+      "Requirement already satisfied: PyJWT<3,>=1.0.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from PyJWT[crypto]<3,>=1.0.0->msal>=1.30.0->azure-identity>=1.25.1->openaivec) (2.10.1)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from requests>=2.21.0->azure-core>=1.31.0->azure-identity>=1.25.1->openaivec) (3.4.4)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from requests>=2.21.0->azure-core>=1.31.0->azure-identity>=1.25.1->openaivec) (2.5.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from requests>=2.21.0->azure-core>=1.31.0->azure-identity>=1.25.1->openaivec) (2025.10.5)\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openai>=2.0.0->openaivec) (4.10.0)\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openai>=2.0.0->openaivec) (1.9.0)\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openai>=2.0.0->openaivec) (0.28.1)\n",
+      "Requirement already satisfied: jiter<1,>=0.10.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openai>=2.0.0->openaivec) (0.12.0)\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openai>=2.0.0->openaivec) (2.12.4)\n",
+      "Requirement already satisfied: sniffio in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from openai>=2.0.0->openaivec) (1.3.1)\n",
+      "Requirement already satisfied: httpcore==1.* in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from httpx<1,>=0.23.0->openai>=2.0.0->openaivec) (1.0.9)\n",
+      "Requirement already satisfied: h11>=0.16 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai>=2.0.0->openaivec) (0.16.0)\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->openai>=2.0.0->openaivec) (0.6.0)\n",
+      "Requirement already satisfied: pydantic-core==2.41.5 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->openai>=2.0.0->openaivec) (2.41.5)\n",
+      "Requirement already satisfied: typing-inspection>=0.4.2 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->openai>=2.0.0->openaivec) (0.4.2)\n",
+      "Requirement already satisfied: numpy>=1.26.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from pandas>=3.0.0->openaivec) (1.26.4)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from pandas>=3.0.0->openaivec) (2.9.0.post0)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from pexpect>4.3->ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (0.7.0)\n",
+      "Requirement already satisfied: six>=1.5 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from python-dateutil>=2.8.2->pandas>=3.0.0->openaivec) (1.17.0)\n",
+      "Requirement already satisfied: executing>=1.2.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (2.2.1)\n",
+      "Requirement already satisfied: asttokens>=2.1.0 in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (3.0.0)\n",
+      "Requirement already satisfied: pure_eval in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets>=8.1.7->openaivec) (0.2.3)\n",
+      "Requirement already satisfied: regex in /home/trusted-service-user/jupyter-env/python3.12/lib/python3.12/site-packages (from tiktoken>=0.9.0->openaivec) (2025.9.1)\n",
+      "Downloading openaivec-2.3.1-py3-none-any.whl (124 kB)\n",
+      "Downloading openai-2.38.0-py3-none-any.whl (1.3 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m38.2 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0m\n",
+      "\u001b[?25hDownloading pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (10.9 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.9/10.9 MB\u001b[0m \u001b[31m112.3 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0m\n",
+      "\u001b[?25hDownloading tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl (1.1 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.1/1.1 MB\u001b[0m \u001b[31m30.4 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: tiktoken, pandas, openai, openaivec\n",
+      "\u001b[2K  Attempting uninstall: pandas\n",
+      "\u001b[2K    Found existing installation: pandas 2.3.3\n",
+      "\u001b[2K    Uninstalling pandas-2.3.3:0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1/4\u001b[0m [pandas]\n",
+      "\u001b[2K   \u001b[91m━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1/4\u001b[0m [pandas]"
+     ]
+    }
+   ],
+   "source": [
+    "%pip uninstall -y openai\n",
+    "%pip install -U openaivec\n",
+    "%pip install -U azure-identity\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bfebeee",
+   "metadata": {},
+   "source": [
+    "## 2. Configure environment variables (placeholders)\n",
+    "\n",
+    "openaivec evaluates the following environment variables to decide how to authenticate:\n",
+    "\n",
+    "| Variable | Purpose |\n",
+    "| --- | --- |\n",
+    "| `AZURE_TENANT_ID` | Tenant ID of the Service Principal used against Azure OpenAI. |\n",
+    "| `AZURE_CLIENT_ID` | Client ID of that Service Principal. |\n",
+    "| `KEY_VAULT_URL` | URL of the Key Vault that stores the SP's client secret. |\n",
+    "| `KEY_VAULT_SECRET_NAME` | Name of the secret inside that Key Vault. |\n",
+    "| `AZURE_OPENAI_BASE_URL` | Azure OpenAI / Foundry base URL in **v1 format** (must end with `/openai/v1/`). |\n",
+    "\n",
+    "Inside Fabric, openaivec detects `notebookutils`, calls `notebookutils.credentials.getSecret(KEY_VAULT_URL, KEY_VAULT_SECRET_NAME)` **as the Fabric workspace identity**, and then builds a `ClientSecretCredential` (or its async equivalent from `azure.identity.aio`) from the resulting secret. Make sure the Fabric workspace itself has been granted `Key Vault Secrets User` on the vault — see the prerequisites above.\n",
+    "\n",
+    "> Replace every `<...>` placeholder with your own value before running the next cell.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88d0218b-4ea0-42b4-b2b2-adf2b52b131c",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-28T01:16:19.7462136Z",
+       "execution_start_time": "2026-05-28T01:16:19.2671437Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "af9b5fbb-d38c-4288-8731-f2113d19b6d6",
+       "queued_time": "2026-05-28T01:16:19.2655586Z",
+       "session_id": "a332235b-2c4e-49f7-8db5-7e4309c133c6",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "# --- Service Principal used against Azure OpenAI / Foundry ---\n",
+    "os.environ[\"AZURE_TENANT_ID\"] = \"<YOUR_TENANT_ID>\"\n",
+    "os.environ[\"AZURE_CLIENT_ID\"] = \"<YOUR_SP_CLIENT_ID>\"\n",
+    "\n",
+    "# --- Key Vault that stores the SP client secret.\n",
+    "#     The Fabric workspace identity (Workspace ID) must have\n",
+    "#     `Key Vault Secrets User` on this vault. ---\n",
+    "os.environ[\"KEY_VAULT_URL\"] = \"https://<your-keyvault>.vault.azure.net/\"\n",
+    "os.environ[\"KEY_VAULT_SECRET_NAME\"] = \"<your-secret-name>\"\n",
+    "\n",
+    "# --- Azure OpenAI / Foundry endpoint (v1 format) ---\n",
+    "os.environ[\"AZURE_OPENAI_BASE_URL\"] = (\n",
+    "    \"https://<your-resource>.services.ai.azure.com/openai/v1/\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a62ee885",
+   "metadata": {},
+   "source": [
+    "## 3. Import libraries and initialize openaivec\n",
+    "\n",
+    "All symbols used by the notebook are imported here in one place. Importing `pandas_ext` registers the `.ai` / `.aio` accessors on pandas `Series` and `DataFrame`. The final line runs a tiny smoke test (English → French translation) to confirm that authentication, model selection, and network reachability all work end-to-end.\n",
+    "\n",
+    "> Replace the model name with one of your **multimodal-capable** deployments — it is required because the pipeline feeds PDF bytes directly to the model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13c20899-0381-4412-b877-c62b49ceefb9",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-28T01:16:38.6612052Z",
+       "execution_start_time": "2026-05-28T01:16:25.5843839Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "8b2357aa-27f6-45e2-9e60-6769f26c3841",
+       "queued_time": "2026-05-28T01:16:25.5828768Z",
+       "session_id": "a332235b-2c4e-49f7-8db5-7e4309c133c6",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ac23127fee4b46c5b2f8b48798a3d8f1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processing batches:   0%|          | 0/2 [00:00<?, ?item/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0     pomme\n",
+       "1    banane\n",
+       "dtype: str"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Standard library\n",
+    "from enum import Enum\n",
+    "\n",
+    "# Third-party\n",
+    "import duckdb\n",
+    "import pandas as pd\n",
+    "from deltalake.writer import write_deltalake\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "# openaivec\n",
+    "import openaivec\n",
+    "from openaivec import pandas_ext  # noqa: F401  registers the .ai / .aio accessor\n",
+    "from openaivec.duckdb_ext import responses_udf\n",
+    "\n",
+    "# Name of a deployed multimodal-capable model\n",
+    "openaivec.set_responses_model(\"<YOUR_MULTIMODAL_DEPLOYMENT>\")\n",
+    "\n",
+    "# Smoke test: if this returns a French translation,\n",
+    "# auth + model + network are all working.\n",
+    "pd.Series([\"apple\", \"banana\"]).ai.responses(\"Translate to French.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c50fd26",
+   "metadata": {},
+   "source": [
+    "## 4. Open an in-memory DuckDB connection\n",
+    "\n",
+    "DuckDB is a single-process OLAP engine. It runs entirely inside the Fabric Notebook's Python kernel and can read OneLake files directly via the POSIX path that Fabric mounts under `/lakehouse/default/Files/...`.\n",
+    "\n",
+    "We create one connection that will host the UDF registration and all subsequent SQL.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac62a6c9-26f0-4d97-97c7-4ab025641a8d",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-28T01:17:13.2831982Z",
+       "execution_start_time": "2026-05-28T01:17:12.8146211Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "f8582ef0-a76d-4a29-8d52-0bf038a8b39a",
+       "queued_time": "2026-05-28T01:17:12.8131123Z",
+       "session_id": "a332235b-2c4e-49f7-8db5-7e4309c133c6",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "conn = duckdb.connect()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89348b81",
+   "metadata": {},
+   "source": [
+    "## 5. Define the extraction schema (Pydantic)\n",
+    "\n",
+    "We declare *what to extract from each PDF* as a **Pydantic model**. `responses_udf` forwards this schema to Azure OpenAI as a Structured Output (`response_format`), which gives us:\n",
+    "\n",
+    "- the LLM can only return JSON that conforms to the schema,\n",
+    "- values are automatically validated and converted to Python types,\n",
+    "- `Enum` fields constrain allowed values to a fixed set.\n",
+    "\n",
+    "For this sample we model an inventory transfer slip as `InventoryTransferSlip`, along with its line items (`TransferItem`) and two enums.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32d08357-c574-43db-a277-0529fe2c011b",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-28T01:17:45.1850684Z",
+       "execution_start_time": "2026-05-28T01:17:44.7730061Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "a5af1f86-cd2f-4e95-b598-25193b753e20",
+       "queued_time": "2026-05-28T01:17:44.7714757Z",
+       "session_id": "a332235b-2c4e-49f7-8db5-7e4309c133c6",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "class InventoryCategory(str, Enum):\n",
+    "    \"\"\"Inventory item category.\"\"\"\n",
+    "    RAW_MATERIAL = \"原材料\"\n",
+    "    PARTS = \"部品\"\n",
+    "    FINISHED_GOODS = \"製品\"\n",
+    "    PACKAGING = \"梱包資材\"\n",
+    "    CONSUMABLES = \"消耗品\"\n",
+    "\n",
+    "\n",
+    "class TransferStatus(str, Enum):\n",
+    "    \"\"\"Slip status.\"\"\"\n",
+    "    PENDING = \"申請中\"\n",
+    "    APPROVED = \"承認済\"\n",
+    "    IN_TRANSIT = \"移動中\"\n",
+    "    COMPLETED = \"完了\"\n",
+    "    PARTIAL = \"一部完了\"\n",
+    "\n",
+    "\n",
+    "class TransferItem(BaseModel):\n",
+    "    \"\"\"A single line item on a transfer slip.\"\"\"\n",
+    "    sku: str\n",
+    "    name: str\n",
+    "    category: InventoryCategory\n",
+    "    unit: str\n",
+    "    quantity: int\n",
+    "    unit_price: float\n",
+    "    amount: float\n",
+    "\n",
+    "\n",
+    "class InventoryTransferSlip(BaseModel):\n",
+    "    \"\"\"Structured representation of an inventory transfer slip.\"\"\"\n",
+    "    slip_number: str\n",
+    "    date: str\n",
+    "    source_warehouse_code: str\n",
+    "    source_warehouse_name: str\n",
+    "    destination_warehouse_code: str\n",
+    "    destination_warehouse_name: str\n",
+    "    department: str\n",
+    "    requester: str\n",
+    "    approver: str\n",
+    "    reason: str\n",
+    "    status: TransferStatus\n",
+    "    items: list[TransferItem]\n",
+    "    total_quantity: int\n",
+    "    total_amount: float\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcd7648f",
+   "metadata": {},
+   "source": [
+    "## 6. Register `parse_transfer_slip` as a DuckDB UDF\n",
+    "\n",
+    "`openaivec.duckdb_ext.responses_udf` registers a scalar function on a DuckDB connection that calls the Azure OpenAI Responses API. Key parameters:\n",
+    "\n",
+    "- `instructions`: system prompt describing **what** to extract and **how** to format it.\n",
+    "- `response_format`: the Pydantic model from the previous cell — LLM output is guaranteed to match it.\n",
+    "- `batch_size=1`: one PDF per request (multimodal inputs are most reliable when sent individually).\n",
+    "- `max_concurrency=36`: number of parallel workers; tune against your Azure OpenAI rate limit.\n",
+    "- `multimodal=True`: required flag telling the UDF to treat the input column as files (PDF / images).\n",
+    "\n",
+    "After registration you can simply call `SELECT parse_transfer_slip(file) FROM glob(...)` — it behaves like any other SQL function.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "529832d5-a459-4011-b1df-00b255aada2d",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-28T01:17:48.2185916Z",
+       "execution_start_time": "2026-05-28T01:17:47.7932552Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "d5c326c1-ffa8-4d47-aaec-7d81bb5e2c4a",
+       "queued_time": "2026-05-28T01:17:47.7917586Z",
+       "session_id": "a332235b-2c4e-49f7-8db5-7e4309c133c6",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "responses_udf(\n",
+    "    conn,\n",
+    "    \"parse_transfer_slip\",\n",
+    "    instructions=(\n",
+    "        \"You are a parser for inventory transfer slips. \"\n",
+    "        \"Extract all information from the slip and return it in the structured format. \"\n",
+    "        \"Numbers must not contain currency symbols or thousand separators. \"\n",
+    "        \"Dates must be formatted as YYYY-MM-DD. \"\n",
+    "        \"Split warehouse codes (e.g. 'WH-TK01') and warehouse names into separate fields. \"\n",
+    "        \"Classify each line item into the appropriate inventory category.\"\n",
+    "    ),\n",
+    "    response_format=InventoryTransferSlip,\n",
+    "    batch_size=1,\n",
+    "    max_concurrency=36,\n",
+    "    multimodal=True,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc504c61",
+   "metadata": {},
+   "source": [
+    "## 7. List the input PDF files\n",
+    "\n",
+    "The `glob()` table function enumerates PDFs under `Files/transfer/` of the attached Lakehouse. OneLake is mounted on the Fabric kernel's local filesystem, so the POSIX path `/lakehouse/default/Files/transfer/*.pdf` works directly.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4fcedfef-d9f1-4086-a5b7-e879e3980cbe",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-28T01:17:52.7243474Z",
+       "execution_start_time": "2026-05-28T01:17:51.2867509Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "f3ffd0bd-b784-4a02-a806-b767f65ee4b1",
+       "queued_time": "2026-05-28T01:17:51.2852543Z",
+       "session_id": "a332235b-2c4e-49f7-8db5-7e4309c133c6",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "┌────────────────────────────────────────────────────┐\n",
+       "│                        file                        │\n",
+       "│                      varchar                       │\n",
+       "├────────────────────────────────────────────────────┤\n",
+       "│ /lakehouse/default/Files/transfer/transfer_001.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_002.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_003.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_004.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_005.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_006.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_007.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_008.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_009.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_010.pdf │\n",
+       "│                         ·                          │\n",
+       "│                         ·                          │\n",
+       "│                         ·                          │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_041.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_042.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_043.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_044.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_045.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_046.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_047.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_048.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_049.pdf │\n",
+       "│ /lakehouse/default/Files/transfer/transfer_050.pdf │\n",
+       "├────────────────────────────────────────────────────┤\n",
+       "│                 50 rows (20 shown)                 │\n",
+       "└────────────────────────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conn.sql(\"\"\"\n",
+    "    select\n",
+    "        *\n",
+    "    from glob('/lakehouse/default/Files/transfer/*.pdf')\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aad3fc1",
+   "metadata": {},
+   "source": [
+    "## 8. Parse the PDFs and flatten line items\n",
+    "\n",
+    "This is the core of the notebook. The SQL is structured as three CTEs:\n",
+    "\n",
+    "1. **`parsed`**: call `parse_transfer_slip(file)` on each PDF, producing one `InventoryTransferSlip` STRUCT column.\n",
+    "2. **`items`**: `unnest()` the `items` list (`list[TransferItem]`) so each line item becomes its own row.\n",
+    "3. **Final SELECT**: join header columns with item columns on `slip_number` to build a flat one-row-per-item table.\n",
+    "\n",
+    "The result is materialized as a pandas `DataFrame` via `.to_df()` and handed off to the Delta writer. `responses_udf` handles deduplication, auto-batching, and retries underneath — your code only needs to express the SQL.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "21fc0bc3-ff90-4906-85bf-b5cdfe41ce21",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-22T05:12:44.7584214Z",
+       "execution_start_time": "2026-05-22T05:12:43.8130626Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "39ba57ed-b871-4609-a266-c2d90532b961",
+       "queued_time": "2026-05-22T05:12:03.9752712Z",
+       "session_id": "ab094ed0-027f-4c20-9391-6bf387d0b140",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pandas_dataframe = conn.sql(\"\"\"\n",
+    "    with parsed as (\n",
+    "        select\n",
+    "            parse_transfer_slip(file) as r\n",
+    "        from glob('/lakehouse/default/Files/transfer/*.pdf')\n",
+    "    ), items as (\n",
+    "        select\n",
+    "            r.slip_number,\n",
+    "            unnest(r.items) as item\n",
+    "        from parsed\n",
+    "    )\n",
+    "    select\n",
+    "        r.slip_number,\n",
+    "        r.date,\n",
+    "        r.source_warehouse_code,\n",
+    "        r.source_warehouse_name,\n",
+    "        r.destination_warehouse_code,\n",
+    "        r.destination_warehouse_name,\n",
+    "        r.department,\n",
+    "        r.requester,\n",
+    "        r.approver,\n",
+    "        r.reason,\n",
+    "        r.status,\n",
+    "        items.item.sku as item_sku,\n",
+    "        items.item.name as item_name,\n",
+    "        items.item.category as item_category,\n",
+    "        items.item.unit as item_unit,\n",
+    "        items.item.quantity as item_quantity,\n",
+    "        items.item.unit_price as item_unit_price,\n",
+    "        items.item.amount as item_amount\n",
+    "    from parsed\n",
+    "    left join items\n",
+    "    on parsed.r.slip_number = items.slip_number\n",
+    "\n",
+    "\"\"\").to_df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2f77c2b9-d7e9-4c7e-b515-24f7fc8bc7f4",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-28T01:18:35.2062173Z",
+       "execution_start_time": "2026-05-28T01:18:34.750641Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "f6541d1a-cf1b-4836-b878-9d570d44bc6e",
+       "queued_time": "2026-05-28T01:18:34.7490835Z",
+       "session_id": "a332235b-2c4e-49f7-8db5-7e4309c133c6",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "ename": "NameError",
+     "evalue": "name 'pandas_dataframe' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[11]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mpandas_dataframe\u001b[49m\n",
+      "\u001b[31mNameError\u001b[39m: name 'pandas_dataframe' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "pandas_dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8b36cae",
+   "metadata": {},
+   "source": [
+    "## 9. Write to Delta Lake on OneLake\n",
+    "\n",
+    "Save the extracted DataFrame to the attached Lakehouse under `Tables/transfers` as a Delta table. Substitute your own workspace and Lakehouse names into the `abfss://` URI. Once written, the table appears in the Lakehouse Explorer and is queryable from the SQL endpoint, Power BI, and other notebooks.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "650ab5f4-e6d3-4539-9757-9b65fed8df88",
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "jupyter_python"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.statement-meta+json": {
+       "execution_finish_time": "2026-05-21T06:10:34.3507564Z",
+       "execution_start_time": "2026-05-21T06:10:32.8428683Z",
+       "normalized_state": "finished",
+       "parent_msg_id": "75a5a97e-986a-40f0-b323-c77a5a57703f",
+       "queued_time": "2026-05-21T06:10:32.84194Z",
+       "session_id": "1ea8a078-0028-4ce6-afaf-a5e7ec2dc0be",
+       "session_start_time": null
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "write_deltalake(\n",
+    "    \"abfss://<your-workspace>@onelake.dfs.fabric.microsoft.com/<your-lakehouse>.Lakehouse/Tables/transfers\",\n",
+    "    pandas_dataframe,\n",
+    "    mode=\"overwrite\",\n",
+    ")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "dependencies": {
+   "lakehouse": {
+    "default_lakehouse": "68c86db3-0858-4c54-81b8-34cdfbff6bf1",
+    "default_lakehouse_name": "bronze",
+    "default_lakehouse_workspace_id": "c9e46c0d-b8f8-49e8-8b3b-b6b010cbcd1e",
+    "known_lakehouses": [
+     {
+      "id": "68c86db3-0858-4c54-81b8-34cdfbff6bf1"
+     }
+    ]
+   }
+  },
+  "kernel_info": {
+   "jupyter_kernel_name": "python3.12",
+   "name": "jupyter"
+  },
+  "kernelspec": {
+   "display_name": "Jupyter",
+   "name": "jupyter"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "jupyter_python"
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
+  },
+  "spark_compute": {
+   "compute_id": "/trident/default",
+   "session_options": {
+    "conf": {
+     "spark.synapse.nbs.session.timeout": "1200000"
+    }
+   }
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "010eba42329741f9b0c0e5113fe823d1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "06c77ac38c53417183ea1a9863cb972e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0b174b6f8ddb4b959fd267789c332cc2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0ebf4e615e98423899ec453df3b1512d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_010eba42329741f9b0c0e5113fe823d1",
+       "style": "IPY_MODEL_73df2ccfba37416e84c659ab4fb77265",
+       "value": " 0/2 [00:04&lt;?, ?item/s]"
+      }
+     },
+     "166efc6dcfc14488aa3892a6c7c0c264": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_31cea09d9a1a4b7fafae807436810044",
+       "style": "IPY_MODEL_95e2082055cd4ad681ccc2cb96a9c2ce",
+       "value": "Processing batches:   0%"
+      }
+     },
+     "174917ffa5294c6aaf171cd501080253": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_dd3feed0c68646e4965166fcaa87f07d",
+       "style": "IPY_MODEL_7755f0a14c8041b5b4507f1d667f56a8",
+       "value": " 2/2 [00:04&lt;00:00,  2.25s/item]"
+      }
+     },
+     "1f2368a5a52046cebff19b674cd2e1ea": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "auto"
+      }
+     },
+     "206bd64d620f4c4d9f0003c99b361fc7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "22354f6e9f264898b366e07a41478cfe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "danger",
+       "layout": "IPY_MODEL_696cba8776124df29d7b5397f129a8ea",
+       "max": 2,
+       "style": "IPY_MODEL_4a7e048b9c944fd3ba7513f54e37d4e5"
+      }
+     },
+     "2c4c78c1dab04f0b883f544b90d4b9be": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "31cea09d9a1a4b7fafae807436810044": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "35bbd41b87e94275acce096dce1b01ac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_06c77ac38c53417183ea1a9863cb972e",
+       "style": "IPY_MODEL_745a1edabccb44a9be33434d0e2e3187",
+       "value": " 0/2 [00:00&lt;?, ?item/s]"
+      }
+     },
+     "3feb972b978f4888b586d86738fccdb2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "41a97797f2f54beb8fa63219936b7e0e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_166efc6dcfc14488aa3892a6c7c0c264",
+        "IPY_MODEL_b8122e3c43f646259bdd049da15bef93",
+        "IPY_MODEL_35bbd41b87e94275acce096dce1b01ac"
+       ],
+       "layout": "IPY_MODEL_fed36be4e7964a7db1db411b27a182b9"
+      }
+     },
+     "4471a493008e4d8e9507bd143d5b1681": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "48c000ac540f4c4c9874be61b184a455": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4a7e048b9c944fd3ba7513f54e37d4e5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "58083bbf1e1244f0a29ec9504b7d1cbf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "bar_color": "black",
+       "description_width": ""
+      }
+     },
+     "5fba169e67f74a8784c9ae03c8066a33": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_1f2368a5a52046cebff19b674cd2e1ea",
+       "style": "IPY_MODEL_58083bbf1e1244f0a29ec9504b7d1cbf",
+       "value": 100
+      }
+     },
+     "61ca2463c191468caf341c09c5ae28b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_a7510d51a4944904a5dd796f04b4eecf",
+       "max": 2,
+       "style": "IPY_MODEL_fa0d320e208944d3a36c71dfd21bdccb",
+       "value": 2
+      }
+     },
+     "696cba8776124df29d7b5397f129a8ea": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "73df2ccfba37416e84c659ab4fb77265": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "745a1edabccb44a9be33434d0e2e3187": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "74d65234f5bc47be92919adef20174c1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7755f0a14c8041b5b4507f1d667f56a8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "82938e161b694d9db0a6a2aaba662ce7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4471a493008e4d8e9507bd143d5b1681",
+       "style": "IPY_MODEL_a48a8eb8fabe459f95517ad1c8ae7470",
+       "value": " 0/2 [00:00&lt;?, ?item/s]"
+      }
+     },
+     "8fbbc26e7a724396af4568d4b5eb4693": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2c4c78c1dab04f0b883f544b90d4b9be",
+       "style": "IPY_MODEL_faa00f29311e4e5a8f21889a8c019258",
+       "value": "Processing batches: 100%"
+      }
+     },
+     "95b40e434ff14fcc98e193441764a4bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c29afee61b94488c92898bbb1cd6344b",
+        "IPY_MODEL_22354f6e9f264898b366e07a41478cfe",
+        "IPY_MODEL_0ebf4e615e98423899ec453df3b1512d"
+       ],
+       "layout": "IPY_MODEL_3feb972b978f4888b586d86738fccdb2"
+      }
+     },
+     "95e2082055cd4ad681ccc2cb96a9c2ce": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "9a7511a4f50e49e0ae5cb3fa9f207c7a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9b121f80cfcd46db96a8750b1885c126": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a8deed4302df4c7da2047d0c2279e56e",
+        "IPY_MODEL_9f07d8e203114a74829afcf7312d12a4",
+        "IPY_MODEL_82938e161b694d9db0a6a2aaba662ce7"
+       ],
+       "layout": "IPY_MODEL_206bd64d620f4c4d9f0003c99b361fc7"
+      }
+     },
+     "9f07d8e203114a74829afcf7312d12a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_74d65234f5bc47be92919adef20174c1",
+       "max": 2,
+       "style": "IPY_MODEL_da5adefca19f46d0b0472128cf74d628"
+      }
+     },
+     "a48a8eb8fabe459f95517ad1c8ae7470": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "a7510d51a4944904a5dd796f04b4eecf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a8deed4302df4c7da2047d0c2279e56e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b97fb6715922446b8196574948880728",
+       "style": "IPY_MODEL_ead8bdf536554b16937fc62fb2257bfa",
+       "value": "Processing batches:   0%"
+      }
+     },
+     "ac23127fee4b46c5b2f8b48798a3d8f1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_8fbbc26e7a724396af4568d4b5eb4693",
+        "IPY_MODEL_61ca2463c191468caf341c09c5ae28b4",
+        "IPY_MODEL_174917ffa5294c6aaf171cd501080253"
+       ],
+       "layout": "IPY_MODEL_0b174b6f8ddb4b959fd267789c332cc2"
+      }
+     },
+     "b0abe8e29baa4d72826448cbdbb09639": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b5bad9bf2d0e4fc69c6708638e423c36": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "b8122e3c43f646259bdd049da15bef93": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_9a7511a4f50e49e0ae5cb3fa9f207c7a",
+       "max": 2,
+       "style": "IPY_MODEL_b0abe8e29baa4d72826448cbdbb09639"
+      }
+     },
+     "b97fb6715922446b8196574948880728": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c29afee61b94488c92898bbb1cd6344b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_48c000ac540f4c4c9874be61b184a455",
+       "style": "IPY_MODEL_b5bad9bf2d0e4fc69c6708638e423c36",
+       "value": "Processing batches:   0%"
+      }
+     },
+     "da5adefca19f46d0b0472128cf74d628": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dd3feed0c68646e4965166fcaa87f07d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ead8bdf536554b16937fc62fb2257bfa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "fa0d320e208944d3a36c71dfd21bdccb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "faa00f29311e4e5a8f21889a8c019258": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "fed36be4e7964a7db1db411b27a182b9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Customer Analysis: examples/customer_analysis.ipynb
       - FAQ Generation: examples/generate_faq.ipynb
       - Receipt Parsing (Multimodal): examples/receipt_parsing.ipynb
+      - Fabric + DuckDB (Multimodal PDF): examples/fabric_duckdb.ipynb
       - Token Count and Processing Time: examples/batch_size.ipynb
       - Request Batching Benchmark: examples/benchmark.ipynb
   - API Reference:


### PR DESCRIPTION
Adds a new example notebook `docs/examples/fabric_duckdb.ipynb` that walks through structured PDF extraction inside a Microsoft Fabric Notebook using DuckDB and `openaivec.duckdb_ext.responses_udf`.

Highlights:
- Prerequisites for Fabric workspace / Lakehouse, Azure OpenAI v1 endpoint, and Entra ID (Service Principal + Key Vault) auth.
- Clarifies that `notebookutils.credentials.getSecret` accesses Key Vault as the **Fabric workspace identity** (Workspace ID), not the Service Principal or interactive user — and documents the matching RBAC grant.
- All credentials and endpoints use placeholders.
- Consolidated imports and section-numbered explanations.
- Registered in the mkdocs Examples nav.

GitHub Pages will be refreshed by manually dispatching the `Publish documentation to GitHub Pages` workflow on `main` after merge.